### PR TITLE
Allow live MIDI messages to be sent form UI to engine

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.7.12'
+          flutter-version: '3.10.0'
           channel: 'stable'
           cache: true
 
@@ -91,7 +91,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.7.12'
+          flutter-version: '3.10.0'
           channel: 'stable'
           cache: true
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.10.0'
+          flutter-version: '3.10.1'
           channel: 'stable'
           cache: true
 
@@ -46,7 +46,7 @@ jobs:
 
       # Run code generation
       - name: Run code generation
-        run: flutter pub run build_runner build
+        run: dart run build_runner build
 
       # Check for formatting in Flutter project
       - name: Format Flutter code
@@ -91,7 +91,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.10.0'
+          flutter-version: '3.10.1'
           channel: 'stable'
           cache: true
 
@@ -106,7 +106,7 @@ jobs:
 
       # Run code generation
       - name: Run code generation
-        run: flutter pub run build_runner build
+        run: dart run build_runner build
 
       # Check for formatting in Flutter project
       - name: Format Flutter code

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.10.1'
+          flutter-version: '3.10.2'
           channel: 'stable'
           cache: true
 
@@ -91,7 +91,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.10.1'
+          flutter-version: '3.10.2'
           channel: 'stable'
           cache: true
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,6 +85,7 @@ jobs:
 
       - name: Install dependencies from apt
         run: |
+          sudo apt update
           sudo apt install -y libboost-dev ninja-build llvm clang libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libfreetype-dev mesa-common-dev libasound2-dev freeglut3-dev libxcomposite-dev libgtk-3-dev libasound2-dev libwebkit2gtk-4.0-dev libcurl4-openssl-dev
 
       - name: Install Flutter

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,5 @@
 name: Build Anthem
-on: [push]
+on: [push, pull_request]
 jobs:
   build-windows:
     runs-on: [windows-latest]
@@ -26,7 +26,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.10.2'
+          flutter-version: '3.10.3'
           channel: 'stable'
           cache: true
 
@@ -91,7 +91,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.10.2'
+          flutter-version: '3.10.3'
           channel: 'stable'
           cache: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ app.*.map.json
 /engine/build/
 /engine/generated/
 
+# Visual Studio
+**/out/build/**
+.vs/**
+
 # Flutter generated platform code
 /linux/flutter/generated_plugin_registrant.cc
 /linux/flutter/generated_plugin_registrant.h

--- a/.vscode/snippets.code-snippets
+++ b/.vscode/snippets.code-snippets
@@ -70,5 +70,29 @@
 			"$0",
 			""
 		]
+	},
+
+	"Model Class": {
+		"prefix": ["Model Item"],
+		"scope": "dart",
+		"body": [
+			"import 'package:json_annotation/json_annotation.dart';",
+			"import 'package:mobx/mobx.dart';",
+			"",
+			"part '$2.g.dart';",
+			"",
+			"@JsonSerializable()",
+			"class $1Model extends _$1Model with _$$1Model {",
+			"  $1Model() : super();",
+			"",
+			"  factory $1Model.fromJson(Map<String, dynamic> json) => _$$1ModelFromJson(json);",
+			"}",
+			"",
+			"abstract class _$1Model with Store {",
+			"  _$1Model();",
+			"",
+			"  Map<String, dynamic> toJson() => _$$1ModelToJson(this as PluginModel);",
+			"}"
+		]
 	}
 }

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -41,6 +41,8 @@ set(ANTHEM_ENGINE_SOURCES
     src/main.cpp
     src/anthem.h
     src/anthem.cpp
+    src/plugin_window.h
+    src/plugin_window.cpp
     src/command_handlers/project_command_handler.h
     src/command_handlers/project_command_handler.cpp
     generated/messages_generated.h
@@ -76,6 +78,7 @@ target_link_libraries(
 
   PRIVATE
   tracktion::tracktion_engine
+  juce::juce_gui_basics
 
   PUBLIC
   juce::juce_recommended_config_flags

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -56,6 +56,8 @@ target_sources(AnthemEngine PRIVATE ${ANTHEM_ENGINE_SOURCES})
 
 target_link_libraries(AnthemEngine ${Boost_LIBRARIES})
 
+target_compile_definitions(AnthemEngine PRIVATE JUCE_PLUGINHOST_VST3=1)
+
 if (LINUX)
   target_include_directories(AnthemEngine PRIVATE ${GTK3_INCLUDE_DIRS})
   target_link_directories(AnthemEngine PRIVATE ${GTK3_LIBRARY_DIRS})
@@ -73,7 +75,6 @@ target_link_libraries(
   AnthemEngine
 
   PRIVATE
-  juce::juce_audio_utils
   tracktion::tracktion_engine
 
   PUBLIC

--- a/engine/messages/messages.fbs
+++ b/engine/messages/messages.fbs
@@ -27,23 +27,24 @@ table HeartbeatReply {}
 
 union Command {
   // Application commands
-  Heartbeat,
   Exit,
+  Heartbeat,
 
   // Project commands
   AddArrangement,
-  AddGenerator,
+  AddPlugin,
   DeleteArrangement,
   GetPlugins,
 }
 
 union ReturnValue {
   // Application commands
-  HeartbeatReply,
   ExitReply,
+  HeartbeatReply,
 
   // Project commands
   AddArrangementResponse,
+  AddPluginResponse,
   GetPluginsResponse,
 }
 

--- a/engine/messages/messages.fbs
+++ b/engine/messages/messages.fbs
@@ -35,6 +35,10 @@ union Command {
   AddPlugin,
   DeleteArrangement,
   GetPlugins,
+
+  // ??
+  LiveNoteOn,
+  LiveNoteOff,
 }
 
 union ReturnValue {

--- a/engine/messages/project.fbs
+++ b/engine/messages/project.fbs
@@ -28,6 +28,7 @@ table DeleteArrangement {
 
 table AddPlugin {
   plugin_uri: string;
+  edit_pointer: ulong;
 }
 table AddPluginResponse {
   plugin_pointer: ulong;

--- a/engine/messages/project.fbs
+++ b/engine/messages/project.fbs
@@ -38,3 +38,19 @@ table GetPlugins {}
 table GetPluginsResponse {
   plugins: [string];
 }
+
+// Maybe these should be moved out into another file
+table LiveNoteOn {
+  edit_pointer: ulong;
+
+  // how on earth are we linking things
+  channel: ubyte;
+  note: ubyte;
+  velocity: float; // JUCE apparently encodes this in float
+}
+table LiveNoteOff {
+  edit_pointer: ulong;
+
+  channel: ubyte;
+  note: ubyte;
+}

--- a/engine/messages/project.fbs
+++ b/engine/messages/project.fbs
@@ -31,7 +31,6 @@ table AddPlugin {
   edit_pointer: ulong;
 }
 table AddPluginResponse {
-  plugin_pointer: ulong;
   success: bool;
 }
 

--- a/engine/messages/project.fbs
+++ b/engine/messages/project.fbs
@@ -26,8 +26,12 @@ table DeleteArrangement {
   edit_pointer: ulong;
 }
 
-table AddGenerator {
+table AddPlugin {
   plugin_uri: string;
+}
+table AddPluginResponse {
+  plugin_pointer: ulong;
+  success: bool;
 }
 
 table GetPlugins {}

--- a/engine/src/anthem.cpp
+++ b/engine/src/anthem.cpp
@@ -23,9 +23,7 @@ Anthem::Anthem() {
     engine = std::unique_ptr<tracktion::Engine>(new tracktion::Engine("anthem"));
 
     auto& pluginManager = engine->getPluginManager();
-
-    // Set up JUCE to be able to scan and load plugins of all supported plugin formats
-    pluginManager.pluginFormatManager.addDefaultFormats();
+    pluginManager.initialise();
 
     std::cout << "We can support " << pluginManager.pluginFormatManager.getNumFormats() << " plugin types:" << std::endl;
     for (auto format : pluginManager.pluginFormatManager.getFormats()) {

--- a/engine/src/anthem.cpp
+++ b/engine/src/anthem.cpp
@@ -1,5 +1,34 @@
+/*
+    Copyright (C) 2023 Joshua Wade
+
+    This file is part of Anthem.
+
+    Anthem is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Anthem is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Anthem. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include "anthem.h"
 
 Anthem::Anthem() {
     engine = std::unique_ptr<tracktion::Engine>(new tracktion::Engine("anthem"));
+
+    auto& pluginManager = engine->getPluginManager();
+
+    // Set up JUCE to be able to scan and load plugins of all supported plugin formats
+    pluginManager.pluginFormatManager.addDefaultFormats();
+
+    std::cout << "We can support " << pluginManager.pluginFormatManager.getNumFormats() << " plugin types:" << std::endl;
+    for (auto format : pluginManager.pluginFormatManager.getFormats()) {
+        std::cout << "   - " << format->getName() << std::endl;
+    }
 }

--- a/engine/src/anthem.cpp
+++ b/engine/src/anthem.cpp
@@ -20,8 +20,15 @@
 #include "anthem.h"
 
 Anthem::Anthem() {
+    std::cout << "Initializing Tracktion Engine..." << std::endl;
     engine = std::unique_ptr<tracktion::Engine>(new tracktion::Engine("anthem"));
 
+    std::cout << "Creating a new Tracktion project..." << std::endl;
+    auto file = engine->getTemporaryFileManager().getTempDirectory().getChildFile ("temp_project").withFileExtension (tracktion::projectFileSuffix);
+    tracktion::ProjectManager::TempProject tempProject (engine->getProjectManager(), file, true);
+    project = tempProject.project;
+
+    std::cout << "Initializing plugin manager..." << std::endl;
     auto& pluginManager = engine->getPluginManager();
     pluginManager.initialise();
 

--- a/engine/src/anthem.h
+++ b/engine/src/anthem.h
@@ -26,5 +26,6 @@ class Anthem {
 private:
 public:
     std::unique_ptr<tracktion::Engine> engine;
+    tracktion::engine::Project::Ptr project;
     Anthem();
 };

--- a/engine/src/command_handlers/project_command_handler.cpp
+++ b/engine/src/command_handlers/project_command_handler.cpp
@@ -31,6 +31,9 @@ std::optional<flatbuffers::Offset<Response>> handleProjectCommand(
         case Command_AddArrangement: {
             auto edit = tracktion::createEmptyEdit(*anthem->engine, juce::File("./I-dont-know-where-this-is-going.tracktion-edit"));
 
+            edit->playInStopEnabled = true;
+            edit->getTransport().ensureContextAllocated(true);
+
             // We store this pointer with the arrangement model in the UI, so
             // we need to extract it from the unique_ptr.
             auto editPtr = edit.release();

--- a/engine/src/command_handlers/project_command_handler.cpp
+++ b/engine/src/command_handlers/project_command_handler.cpp
@@ -81,7 +81,7 @@ std::optional<flatbuffers::Offset<Response>> handleProjectCommand(
             std::cout << "Scanned plugin." << std::endl;
 
             if (typesFound.size() == 0) {
-                std::cout << "Plugin scan didn't idenitfy the plugin as valid." << std::endl;
+                std::cout << "Plugin scan didn't identify the plugin as valid." << std::endl;
                 return std::optional(errorResponseMessage);
             }
 
@@ -96,6 +96,30 @@ std::optional<flatbuffers::Offset<Response>> handleProjectCommand(
 
             if (pluginInstance) {
                 std::cout << "Loaded plugin: " << pluginInstance->getName() << std::endl;
+                // Create a window for the plugin
+                auto pluginWindow = std::make_unique<PluginWindow>(pluginInstance.get());
+                pluginWindow->setVisible(true);
+                
+                // TODO: This is a memory leak, but means the window pointer
+                // isn't deleted. I'm not sure what to do with this yet, but
+                // either way the pointer should be stored somewhere for access
+                // later.
+                pluginWindow.release();
+
+                auto edit = reinterpret_cast<tracktion::engine::Edit*>(
+                    static_cast<uintptr_t>(command->edit_pointer())
+                );
+
+                // Get a reference to the main track list
+                // auto& trackList = edit->getTrackList();
+
+                // Create the TrackInsertPoint
+                // tracktion::TrackInsertPoint tip(nullptr, nullptr); // Always inserts at the start - TODO figure this out lol
+
+                // // Insert the new audio track
+                // auto newTrack = edit->insertNewAudioTrack(tip, nullptr);
+
+                // newTrack->pluginList.insertPlugin(pluginInstance);
             } else {
                 std::cout << "Error: " << errorMessage.toStdString() << std::endl;
                 return std::optional(errorResponseMessage);

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -267,18 +267,10 @@ public:
         std::cout << "Starting Anthem engine..." << std::endl;
         anthem = new Anthem();
 
-        // This starts the message loop in a thread. It also means that all our
-        // commands will be handled on a separate thread from the main JUCE
-        // event loop thread. This might be fine, since we're not using JUCE as
-        // a GUI library, but I don't know.
-        //
-        // However, this does fix an issue. JUCE crashes the application if we
-        // try to exit before the `initialize()` function is returned from. I'm
-        // guessing that JUCE needs to do at least something in the main thread
-        // after it calls our initialize function.
-        //
-        // If we start getting weird crashes, then this might be something to
-        // look at.
+        // This starts the message loop in a thread. The message loop thread
+        // communicates back to the main thread every time it receives a
+        // message from the UI, and the main thread takes care of processing
+        // the message.
         message_loop_thread = std::make_unique<std::thread>(messageLoop, std::ref(commandMessageListener));
         message_loop_thread->detach();
     }

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -17,6 +17,8 @@
     along with Anthem. If not, see <https://www.gnu.org/licenses/>.
 */
 
+#define JUCE_CHECK_MEMORY_LEAKS 0
+
 #include <juce_core/juce_core.h>
 #include <juce_events/juce_events.h>
 #include <juce_audio_devices/juce_audio_devices.h>
@@ -139,7 +141,7 @@ void messageLoop() {
                 break;
             }
             case Command_AddArrangement:
-            case Command_AddGenerator:
+            case Command_AddPlugin:
             case Command_DeleteArrangement:
             case Command_GetPlugins:
                 response = handleProjectCommand(request, builder, anthem);
@@ -205,6 +207,7 @@ public:
 
     void initialise(const juce::String &commandLineParameters) override
     {
+                                    // wow, C++ sure is weird
         const char * anthemSplash = R"V0G0N(
            ,++,
           /####\

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -120,6 +120,8 @@ public:
             case Command_AddPlugin:
             case Command_DeleteArrangement:
             case Command_GetPlugins:
+            case Command_LiveNoteOn:
+            case Command_LiveNoteOff:
                 response = handleProjectCommand(request, builder, anthem);
                 break;
             default: {

--- a/engine/src/plugin_window.cpp
+++ b/engine/src/plugin_window.cpp
@@ -1,0 +1,51 @@
+/*
+    Copyright (C) 2023 Joshua Wade
+
+    This file is part of Anthem.
+
+    Anthem is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Anthem is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Anthem. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "plugin_window.h"
+
+PluginWindow::PluginWindow(juce::AudioProcessor* processor)
+    : DocumentWindow(processor->getName(),
+                     juce::Colours::lightgrey,
+                     juce::DocumentWindow::allButtons)
+{
+    auto* editor = processor->createEditorIfNeeded();
+    if (editor != nullptr)
+    {
+        setContentOwned(editor, true);
+        setResizable(false, false);
+        setUsingNativeTitleBar(true);
+        setSize(editor->getWidth(), editor->getHeight());
+        centreWithSize(getWidth(), getHeight());
+    }
+    else
+    {
+        jassertfalse; // The plugin should have a valid editor
+    }
+}
+
+PluginWindow::~PluginWindow()
+{
+    // Make sure to remove the editor and release the plugin instance
+    setContentOwned(nullptr, true);
+}
+
+void PluginWindow::closeButtonPressed()
+{
+    setVisible(false);
+}

--- a/engine/src/plugin_window.h
+++ b/engine/src/plugin_window.h
@@ -20,9 +20,16 @@
 #pragma once
 
 #include <tracktion_engine/tracktion_engine.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
-#include "messages_generated.h"
-#include "../anthem.h"
-#include "../plugin_window.h"
+class PluginWindow : public juce::DocumentWindow
+{
+public:
+    PluginWindow(juce::AudioProcessor* processor);
+    ~PluginWindow();
 
-std::optional<flatbuffers::Offset<Response>> handleProjectCommand(const Request* request, flatbuffers::FlatBufferBuilder& builder, Anthem* anthem);
+    void closeButtonPressed() override;
+
+private:
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PluginWindow)
+};

--- a/lib/commands/project_commands.dart
+++ b/lib/commands/project_commands.dart
@@ -21,6 +21,7 @@ import 'dart:ui';
 
 import 'package:anthem/helpers/id.dart';
 import 'package:anthem/model/generator.dart';
+import 'package:anthem/model/plugin.dart';
 import 'package:anthem/model/project.dart';
 
 import 'command.dart';
@@ -36,18 +37,24 @@ class AddGeneratorCommand extends Command {
   ID generatorID;
   String name;
   Color color;
+  String pluginPath;
 
   AddGeneratorCommand({
     required ProjectModel project,
     required this.generatorID,
     required this.name,
     required this.color,
+    required this.pluginPath,
   }) : super(project);
 
   @override
   void execute() {
+    final plugin = PluginModel(path: pluginPath)
+      ..createInEngine(project.engine);
+    final generator = GeneratorModel(name: name, color: color, plugin: plugin);
+
     project.generatorList.add(generatorID);
-    project.generators[generatorID] = GeneratorModel(name: name, color: color);
+    project.generators[generatorID] = generator;
   }
 
   @override

--- a/lib/engine_api/api/project.dart
+++ b/lib/engine_api/api/project.dart
@@ -81,7 +81,8 @@ class Project {
     return completer.future;
   }
 
-  Future<int> addPlugin(String pluginPath, int editPointer) {
+  /// Adds the plugin at the given path.
+  Future<void> addPlugin(String pluginPath, int editPointer) {
     final id = _engine._getRequestId();
 
     final request = RequestObjectBuilder(
@@ -93,14 +94,14 @@ class Project {
       ),
     );
 
-    final completer = Completer<int>();
+    final completer = Completer<void>();
 
     _engine._request(id, request, onResponse: (response) {
       final inner = response.returnValue as AddPluginResponse;
       if (inner.success) {
-        completer.complete(inner.pluginPointer);
+        completer.complete();
       } else {
-        completer.completeError(inner.pluginPointer);
+        completer.completeError(false);
       }
     });
 

--- a/lib/engine_api/api/project.dart
+++ b/lib/engine_api/api/project.dart
@@ -80,4 +80,27 @@ class Project {
 
     return completer.future;
   }
+
+  Future<int> addPlugin(String pluginPath) {
+    final id = _engine._getRequestId();
+
+    final request = RequestObjectBuilder(
+      id: id,
+      commandType: CommandTypeId.AddPlugin,
+      command: AddPluginObjectBuilder(pluginUri: pluginPath),
+    );
+
+    final completer = Completer<int>();
+
+    _engine._request(id, request, onResponse: (response) {
+      final inner = response.returnValue as AddPluginResponse;
+      if (inner.success) {
+        completer.complete(inner.pluginPointer);
+      } else {
+        completer.completeError(inner.pluginPointer);
+      }
+    });
+
+    return completer.future;
+  }
 }

--- a/lib/engine_api/api/project.dart
+++ b/lib/engine_api/api/project.dart
@@ -107,4 +107,46 @@ class Project {
 
     return completer.future;
   }
+
+  void noteOn({
+    int channel = 1,
+    required int note,
+    double velocity = 0.5,
+    required int editPointer,
+  }) {
+    final id = _engine._getRequestId();
+
+    final request = RequestObjectBuilder(
+      id: id,
+      commandType: CommandTypeId.LiveNoteOn,
+      command: LiveNoteOnObjectBuilder(
+        editPointer: editPointer,
+        channel: channel,
+        note: note,
+        velocity: velocity,
+      ),
+    );
+
+    _engine._request(id, request);
+  }
+
+  void noteOff({
+    int channel = 1,
+    required int note,
+    required int editPointer,
+  }) {
+    final id = _engine._getRequestId();
+
+    final request = RequestObjectBuilder(
+      id: id,
+      commandType: CommandTypeId.LiveNoteOff,
+      command: LiveNoteOffObjectBuilder(
+        editPointer: editPointer,
+        channel: channel,
+        note: note,
+      ),
+    );
+
+    _engine._request(id, request);
+  }
 }

--- a/lib/engine_api/api/project.dart
+++ b/lib/engine_api/api/project.dart
@@ -81,13 +81,16 @@ class Project {
     return completer.future;
   }
 
-  Future<int> addPlugin(String pluginPath) {
+  Future<int> addPlugin(String pluginPath, int editPointer) {
     final id = _engine._getRequestId();
 
     final request = RequestObjectBuilder(
       id: id,
       commandType: CommandTypeId.AddPlugin,
-      command: AddPluginObjectBuilder(pluginUri: pluginPath),
+      command: AddPluginObjectBuilder(
+        pluginUri: pluginPath,
+        editPointer: editPointer,
+      ),
     );
 
     final completer = Completer<int>();

--- a/lib/engine_api/engine.dart
+++ b/lib/engine_api/engine.dart
@@ -22,6 +22,7 @@ import 'dart:async';
 import 'package:anthem/engine_api/engine_connector.dart';
 import 'package:anthem/generated/messages_generated.dart';
 import 'package:anthem/generated/project_generated.dart';
+import 'package:anthem/model/project.dart';
 
 part 'api/project.dart';
 
@@ -42,6 +43,9 @@ int getEngineID() => _engineIdGenerator++;
 class Engine {
   int id;
   late EngineConnector _engineConnector;
+
+  ProjectModel project;
+
   late Project projectApi;
 
   Map<int, void Function(Response response)> replyFunctions = {};
@@ -54,7 +58,7 @@ class Engine {
 
   EngineState _engineState = EngineState.stopped;
 
-  Engine(this.id) {
+  Engine(this.id, this.project) {
     engineStateStream = _engineStateStreamController.stream;
 
     projectApi = Project(this);

--- a/lib/engine_api/engine_connector.dart
+++ b/lib/engine_api/engine_connector.dart
@@ -29,7 +29,7 @@ import 'package:anthem/generated/messages_generated.dart';
 /// Set this to override the path to the engine. Should be a full path.
 ///
 /// This will allow you to stop the engine from Anthem, compile a new engine,
-/// and start the new enine, all without re-building the Anthem UI.
+/// and start the new engine, all without re-building the Anthem UI.
 // ignore: unnecessary_nullable_for_final_variable_declarations
 const String? enginePathOverride = null;
 
@@ -480,7 +480,7 @@ class EngineConnector {
 
 /// Isolate thread function to connect to the engine.
 ///
-/// Connecting to a new enigne involves starting the engine process and then
+/// Connecting to a new engine involves starting the engine process and then
 /// repeatedly checking for the engine-to-UI message queue that should be
 /// created by the engine. This task blocks the thread that does it, so we
 /// offload this work to an isolate. This allows Flutter to continue rendering
@@ -530,7 +530,7 @@ void _requestSenderIsolate(SendPort sendPort) {
   // The main thread will send a message with the message size when it wants
   // this thread to send from the dynamic library's buffer.
   receivePort.listen((message) {
-    // The first message will alwyas be the engine ID
+    // The first message will always be the engine ID
     if (engineID == null) {
       engineID = message as int;
       return;

--- a/lib/engine_api/engine_connector.dart
+++ b/lib/engine_api/engine_connector.dart
@@ -402,6 +402,12 @@ class EngineConnector {
       await _requestIsolateSendPortAvailable.future;
     }
 
+    // Acts as a mutex. If there are multiple requests that reach here, only
+    // one will be able to pass at a time.
+    while (!_requestCompleted.isCompleted) {
+      await _requestCompleted.future;
+    }
+
     _requestCompleted = Completer();
 
     // Tell the request isolate to send the message in the request buffer

--- a/lib/engine_api/engine_connector.dart
+++ b/lib/engine_api/engine_connector.dart
@@ -26,7 +26,7 @@ import 'package:flutter/foundation.dart';
 
 import 'package:anthem/generated/messages_generated.dart';
 
-/// Set this to override the path to the engine.
+/// Set this to override the path to the engine. Should be a full path.
 ///
 /// This will allow you to stop the engine from Anthem, compile a new engine,
 /// and start the new enine, all without re-building the Anthem UI.

--- a/lib/model/generator.dart
+++ b/lib/model/generator.dart
@@ -20,6 +20,7 @@
 import 'dart:ui';
 import 'package:anthem/helpers/convert.dart';
 import 'package:anthem/helpers/id.dart';
+import 'package:anthem/model/plugin.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:mobx/mobx.dart';
 
@@ -27,8 +28,9 @@ part 'generator.g.dart';
 
 @JsonSerializable()
 class GeneratorModel extends _GeneratorModel with _$GeneratorModel {
-  GeneratorModel({required String name, required Color color})
-      : super(name: name, color: color);
+  GeneratorModel(
+      {required String name, required Color color, required PluginModel plugin})
+      : super(name: name, color: color, plugin: plugin);
 
   factory GeneratorModel.fromJson(Map<String, dynamic> json) =>
       _$GeneratorModelFromJson(json);
@@ -44,9 +46,13 @@ abstract class _GeneratorModel with Store {
   @observable
   Color color;
 
+  @observable
+  PluginModel plugin;
+
   _GeneratorModel({
     required this.name,
     required this.color,
+    required this.plugin,
   }) : id = getID();
 
   Map<String, dynamic> toJson() =>

--- a/lib/model/plugin.dart
+++ b/lib/model/plugin.dart
@@ -1,0 +1,53 @@
+/*
+  Copyright (C) 2023 Joshua Wade
+
+  This file is part of Anthem.
+
+  Anthem is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Anthem is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Anthem. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import 'package:anthem/engine_api/engine.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:mobx/mobx.dart';
+
+part 'plugin.g.dart';
+
+/// A model representing a plugin.
+@JsonSerializable()
+class PluginModel extends _PluginModel with _$PluginModel {
+  PluginModel({required String path}) : super(path: path);
+
+  factory PluginModel.fromJson(Map<String, dynamic> json) =>
+      _$PluginModelFromJson(json);
+}
+
+abstract class _PluginModel with Store {
+  String path;
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  late int pluginInstancePointer;
+
+  _PluginModel({required this.path});
+
+  Map<String, dynamic> toJson() => _$PluginModelToJson(this as PluginModel);
+
+  Future<bool> createInEngine(Engine engine) async {
+    try {
+      pluginInstancePointer = await engine.projectApi.addPlugin(path);
+      return true;
+    } catch (ex) {
+      return false;
+    }
+  }
+}

--- a/lib/model/plugin.dart
+++ b/lib/model/plugin.dart
@@ -43,8 +43,22 @@ abstract class _PluginModel with Store {
   Map<String, dynamic> toJson() => _$PluginModelToJson(this as PluginModel);
 
   Future<bool> createInEngine(Engine engine) async {
+    // TODO: For now, we're just grabbing the first arrangement. Really,
+    // plugins should be added to all arrangements. This is an issue with
+    // trying to align with Tracktion Engine, since Tracktion Engine treats
+    // edits as having separate track lists, whereas we want a single track
+    // list to span across all arrangements.
+    //
+    // But back to the TODO - this effectively means we must have exactly one
+    // arrangement at once, or bad things will happen. We need to fix this.
+    //
+    // Maybe we need a better abstraction between us and Tracktion Engine?
     try {
-      pluginInstancePointer = await engine.projectApi.addPlugin(path);
+      pluginInstancePointer = await engine.projectApi.addPlugin(
+        path,
+        engine.project.song
+            .arrangements[engine.project.song.activeArrangementID]!.editPointer,
+      );
       return true;
     } catch (ex) {
       return false;

--- a/lib/model/plugin.dart
+++ b/lib/model/plugin.dart
@@ -35,9 +35,6 @@ class PluginModel extends _PluginModel with _$PluginModel {
 abstract class _PluginModel with Store {
   String path;
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  late int pluginInstancePointer;
-
   _PluginModel({required this.path});
 
   Map<String, dynamic> toJson() => _$PluginModelToJson(this as PluginModel);
@@ -54,7 +51,7 @@ abstract class _PluginModel with Store {
     //
     // Maybe we need a better abstraction between us and Tracktion Engine?
     try {
-      pluginInstancePointer = await engine.projectApi.addPlugin(
+      await engine.projectApi.addPlugin(
         path,
         engine.project.song
             .arrangements[engine.project.song.activeArrangementID]!.editPointer,

--- a/lib/model/project.dart
+++ b/lib/model/project.dart
@@ -150,7 +150,7 @@ abstract class _ProjectModel extends Hydratable with Store {
       project: this as ProjectModel,
     );
 
-    engine = Engine(engineID)..start();
+    engine = Engine(engineID, this as ProjectModel)..start();
 
     engine.engineStateStream.listen((state) {
       (this as ProjectModel).engineState = state;
@@ -172,7 +172,7 @@ abstract class _ProjectModel extends Hydratable with Store {
       project: this as ProjectModel,
     );
 
-    engine = Engine(engineID)..start();
+    engine = Engine(engineID, this as ProjectModel)..start();
 
     isHydrated = true;
   }

--- a/lib/model/project.dart
+++ b/lib/model/project.dart
@@ -163,6 +163,17 @@ abstract class _ProjectModel extends Hydratable with Store {
     isHydrated = true;
   }
 
+  // Initializes this project in the engine
+  Future<void> createInEngine() async {
+    for (final arrangement in song.arrangements.values) {
+      await arrangement.createInEngine(engine);
+    }
+
+    for (final generator in generators.values) {
+      await generator.plugin.createInEngine(engine);
+    }
+  }
+
   Map<String, dynamic> toJson() => _$ProjectModelToJson(this as ProjectModel);
 
   /// This function is run after deserialization. It allows us to do some setup

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -59,8 +59,11 @@ class _Control {
   Color border = const Color(0xFF293136);
 }
 
+const _textMain = Color(0xFF9DB9CC);
+
 class _Text {
-  Color main = const Color(0xFF9DB9CC);
+  Color main = _textMain;
+  Color disabled = _textMain.withAlpha(125);
 }
 
 class _ByBackgroundType {

--- a/lib/widgets/basic/icon.dart
+++ b/lib/widgets/basic/icon.dart
@@ -62,6 +62,7 @@ class Icons {
   static IconDef undo = const IconDef('assets/icons/edit/undo.svg');
   static _ScrollbarIcons scrollbar = _ScrollbarIcons();
   static _ToolIcons tools = _ToolIcons();
+  static _MainToolbarIcons mainToolbar = _MainToolbarIcons();
 }
 
 class _ScrollbarIcons {
@@ -76,6 +77,11 @@ class _ToolIcons {
   IconDef erase = const IconDef('assets/icons/tools/erase.svg');
   IconDef pencil = const IconDef('assets/icons/tools/pencil.svg');
   IconDef select = const IconDef('assets/icons/tools/select.svg');
+}
+
+class _MainToolbarIcons {
+  IconDef typingKeyboardToPianoKeyboard = const IconDef(
+      'assets/icons/main_toolbar/typing_keyboard_to_piano_keyboard.svg');
 }
 
 class SvgIcon extends StatelessWidget {

--- a/lib/widgets/basic/menu/menu_model.dart
+++ b/lib/widgets/basic/menu/menu_model.dart
@@ -35,12 +35,14 @@ class AnthemMenuItem extends GenericMenuItem {
   MenuDef? submenu;
   VoidCallback? onSelected;
   String? hint;
+  bool disabled;
 
   AnthemMenuItem({
     this.text = '',
     this.submenu,
     this.onSelected,
     this.hint,
+    this.disabled = false,
   }) : super();
 }
 

--- a/lib/widgets/basic/menu/menu_renderer.dart
+++ b/lib/widgets/basic/menu/menu_renderer.dart
@@ -200,7 +200,11 @@ class _MenuItemRendererState extends State<MenuItemRenderer> {
       final showHoverState =
           isHovered || (isSubmenuOpen && !widget.isMouseInMenu);
 
-      final textColor = showHoverState ? Theme.primary.main : Theme.text.main;
+      final textColor = showHoverState
+          ? Theme.primary.main
+          : item.disabled
+              ? Theme.text.disabled
+              : Theme.text.main;
 
       final rowChildren = [
         Text(
@@ -232,6 +236,8 @@ class _MenuItemRendererState extends State<MenuItemRenderer> {
 
       return MouseRegion(
         onEnter: (e) {
+          if (item.disabled) return;
+
           setState(() {
             isHovered = true;
           });
@@ -252,6 +258,8 @@ class _MenuItemRendererState extends State<MenuItemRenderer> {
           cancelSubmenuCloseTimer();
         },
         onExit: (e) {
+          if (item.disabled) return;
+
           setState(() {
             isHovered = false;
           });
@@ -260,6 +268,8 @@ class _MenuItemRendererState extends State<MenuItemRenderer> {
         },
         child: GestureDetector(
           onTap: () {
+            if (item.disabled) return;
+
             item.onSelected?.call();
             if (item.submenu == null) {
               screenOverlayController.clear();

--- a/lib/widgets/basic/panel.dart
+++ b/lib/widgets/basic/panel.dart
@@ -33,6 +33,11 @@ bool _isPanelFirst(PanelOrientation orientation) {
       orientation == PanelOrientation.top;
 }
 
+// Tracks if a resize is already active. We use this to enable logic that
+// prevents multiple resize handles from triggering resize operations at once,
+// in the case that resize indicators are overlapping.
+bool isResizeActive = false;
+
 class Panel extends StatefulWidget {
   final Widget panelContent;
   final Widget child;
@@ -73,7 +78,7 @@ class _PanelState extends State<Panel> {
   double pixelPanelSize = -1;
 
   // event variables, not used during render
-  bool mouseDown = false;
+  bool resizeActive = false;
   double startPos = -1;
   double startSize = -1;
 
@@ -190,17 +195,22 @@ class _PanelState extends State<Panel> {
                 opaque: false,
                 child: Listener(
                   onPointerDown: (e) {
-                    mouseDown = true;
+                    if (isResizeActive) return;
+                    isResizeActive = true;
+                    resizeActive = true;
                     startPos = (horizontal ? e.position.dx : e.position.dy);
                     startSize = panelSize;
                   },
                   onPointerUp: (e) {
-                    mouseDown = false;
+                    resizeActive = false;
+                    isResizeActive = false;
                   },
                   onPointerCancel: (e) {
-                    mouseDown = false;
+                    resizeActive = false;
+                    isResizeActive = false;
                   },
                   onPointerMove: (e) {
+                    if (!resizeActive) return;
                     final delta =
                         ((horizontal ? e.position.dx : e.position.dy) -
                                 startPos) *

--- a/lib/widgets/basic/panel.dart
+++ b/lib/widgets/basic/panel.dart
@@ -97,9 +97,15 @@ class _PanelState extends State<Panel> {
         }
       }
 
-      final panelSize = widget.sizeBehavior == PanelSizeBehavior.flex
+      var panelSize = widget.sizeBehavior == PanelSizeBehavior.flex
           ? flexPanelSize * mainAxisSize
           : pixelPanelSize;
+
+      // Make sure we're snapping to a pixel boundary
+      final queryData = MediaQuery.of(context);
+      panelSize *= queryData.devicePixelRatio;
+      panelSize = panelSize.round().toDouble();
+      panelSize /= queryData.devicePixelRatio;
 
       final panelFirst = _isPanelFirst(widget.orientation);
 

--- a/lib/widgets/basic/panel.dart
+++ b/lib/widgets/basic/panel.dart
@@ -131,7 +131,7 @@ class _PanelState extends State<Panel> {
       contentHugTop |= panelHidden;
       contentHugBottom |= panelHidden;
 
-      final separatorSize = widget.separatorSize ?? 6.0;
+      final separatorSize = widget.separatorSize ?? 3.0;
       const handleSize = 10.0;
 
       var handleLeft =

--- a/lib/widgets/basic/panel.dart
+++ b/lib/widgets/basic/panel.dart
@@ -126,7 +126,7 @@ class _PanelState extends State<Panel> {
       contentHugTop |= panelHidden;
       contentHugBottom |= panelHidden;
 
-      final separatorSize = widget.separatorSize ?? 3.0;
+      final separatorSize = widget.separatorSize ?? 6.0;
       const handleSize = 10.0;
 
       var handleLeft =

--- a/lib/widgets/basic/shortcuts/shortcut_provider.dart
+++ b/lib/widgets/basic/shortcuts/shortcut_provider.dart
@@ -52,15 +52,25 @@ class KeyboardModifiers with ChangeNotifier, DiagnosticableTreeMixin {
   }
 }
 
-/// This class listens for shortcuts and sends them to the active
+/// This widget listens for shortcuts and sends them to the active
 /// [ShortcutConsumer].
 ///
-/// This class also provides an object to descendants which tells which
-/// modifier keys (control, alt, shift) are currently pressed.
+/// Each open project renders a [ShortcutProvider] widget, and this widget
+/// tracks an active consumer within that provider's scope. This consumer will
+/// usually be an editor, such as the piano roll. Tracking an active UI region
+/// in this way allows us to specify which editor is currently accepting
+/// shortcuts like copy and paste.
+///
+/// This class also provides an object to descendants which tells which modifier
+/// keys (control, alt, shift) are currently pressed.
 class ShortcutProvider extends StatefulWidget {
   final Widget child;
 
-  const ShortcutProvider({Key? key, required this.child}) : super(key: key);
+  /// Determines if this [ShortcutProvider] should process keystrokes.
+  final bool active;
+
+  const ShortcutProvider({Key? key, required this.child, this.active = true})
+      : super(key: key);
 
   @override
   State<ShortcutProvider> createState() => _ShortcutProviderState();
@@ -82,6 +92,8 @@ class _ShortcutProviderState extends State<ShortcutProvider> {
   }
 
   bool _onKey(KeyEvent e) {
+    if (!widget.active) return false;
+
     final keyDown = e is KeyDownEvent;
     final keyUp = e is KeyUpEvent;
     final keyRepeat = e is KeyRepeatEvent;
@@ -103,8 +115,8 @@ class _ShortcutProviderState extends State<ShortcutProvider> {
     if (shift && keyDown) keyboardModifiers.setShift(true);
     if (shift && keyUp) keyboardModifiers.setShift(false);
 
-    if (keyDown || keyRepeat) controller.handleKeyDown(e.logicalKey);
-    if (keyUp) controller.handleKeyUp(e.logicalKey);
+    if (keyDown || keyRepeat) controller.handleKeyDown(e);
+    if (keyUp) controller.handleKeyUp(e);
 
     return false;
   }

--- a/lib/widgets/editors/arranger/arranger.dart
+++ b/lib/widgets/editors/arranger/arranger.dart
@@ -130,6 +130,7 @@ class _ArrangerState extends State<Arranger> {
                                   menuDef: MenuDef(
                                     children: [
                                       AnthemMenuItem(
+                                        disabled: true,
                                         text: 'New arrangement',
                                         hint: 'Create a new arrangement',
                                         onSelected: () {

--- a/lib/widgets/editors/arranger/arranger.dart
+++ b/lib/widgets/editors/arranger/arranger.dart
@@ -779,7 +779,9 @@ class _TrackHeadersState extends State<_TrackHeaders> {
           var trackPositionPointer = -widget.verticalScrollPosition;
 
           for (final trackID in project.song.trackOrder) {
-            final heightModifier = viewModel.trackHeightModifiers[trackID]!;
+            final heightModifier = viewModel.trackHeightModifiers[trackID];
+
+            if (heightModifier == null) continue;
 
             final trackHeight = getTrackHeight(
               viewModel.baseTrackHeight,

--- a/lib/widgets/editors/arranger/arranger.dart
+++ b/lib/widgets/editors/arranger/arranger.dart
@@ -106,7 +106,7 @@ class _ArrangerState extends State<Arranger> {
         child: ArrangerTimeViewProvider(
           child: ShortcutConsumer(
             id: 'arranger',
-            handler: controller!.onShortcut,
+            shortcutHandler: controller!.onShortcut,
             child: Container(
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(4),

--- a/lib/widgets/editors/pattern_editor/pattern_editor_controller.dart
+++ b/lib/widgets/editors/pattern_editor/pattern_editor_controller.dart
@@ -34,8 +34,6 @@ class PatternEditorController {
     required Color color,
     required String pluginPath,
   }) {
-    // TODO: Use plugin path to send this to the engine
-
     final id = getID();
 
     project.execute(AddGeneratorCommand(
@@ -43,6 +41,7 @@ class PatternEditorController {
       generatorID: id,
       name: name,
       color: color,
+      pluginPath: pluginPath,
     ));
 
     project.activeGeneratorID = id;

--- a/lib/widgets/editors/piano_roll/piano_roll.dart
+++ b/lib/widgets/editors/piano_roll/piano_roll.dart
@@ -550,7 +550,7 @@ class _PianoRollContentState extends State<_PianoRollContent>
 
     return ShortcutConsumer(
       id: 'piano-roll',
-      handler: controller.onShortcut,
+      shortcutHandler: controller.onShortcut,
       child: Panel(
         orientation: PanelOrientation.bottom,
         sizeBehavior: PanelSizeBehavior.pixels,

--- a/lib/widgets/editors/shared/helpers/time_helpers.dart
+++ b/lib/widgets/editors/shared/helpers/time_helpers.dart
@@ -177,23 +177,26 @@ GetBestDivisionResult getBestDivision({
   int snapSize;
   int skip = 1;
 
-  if (snap is BarSnap) {
-    bestDivision = barLength;
-    snapSize = barLength;
-  } else if (snap is DivisionSnap || snap is AutoSnap) {
-    if (divisionSizeLowerBound >= barLength) {
-      snapSize = barLength;
-    } else {
-      final division = snap is DivisionSnap
-          ? snap.division
-          : Division(multiplier: 1, divisor: 4);
-      snapSize = division.getSizeInTicks(ticksPerQuarter, timeSignature);
-    }
-    bestDivision = snapSize;
-  } else {
-    // We need to update the Snap class to be sealed when 3.0 comes out. Until
-    // then, if Snap gets more subclasses then this could give a runtime error.
-    throw ArgumentError('Unhandled Snap type');
+  switch (snap) {
+    case BarSnap():
+      {
+        bestDivision = barLength;
+        snapSize = barLength;
+        break;
+      }
+    case DivisionSnap() || AutoSnap():
+      {
+        if (divisionSizeLowerBound >= barLength) {
+          snapSize = barLength;
+        } else {
+          final division = snap is DivisionSnap
+              ? snap.division
+              : Division(multiplier: 1, divisor: 4);
+          snapSize = division.getSizeInTicks(ticksPerQuarter, timeSignature);
+        }
+        bestDivision = snapSize;
+        break;
+      }
   }
 
   final numDivisionsInBar = barLength ~/ snapSize;

--- a/lib/widgets/editors/shared/helpers/time_helpers.dart
+++ b/lib/widgets/editors/shared/helpers/time_helpers.dart
@@ -23,8 +23,8 @@ import 'package:anthem/model/shared/time_signature.dart';
 
 import 'types.dart';
 
-const minorMinPixels = 8.0;
-const majorMinPixels = 20.0;
+const minorMinPixels = 12.0;
+const majorMinPixels = 25.0;
 
 double timeToPixels({
   required double timeViewStart,
@@ -241,7 +241,7 @@ GetBestDivisionResult getBestDivision({
 /// section, and one describing the same for the 4/4 section.
 List<DivisionChange> getDivisionChanges({
   required double viewWidthInPixels,
-  double minPixelsPerSection = 8,
+  double minPixelsPerSection = minorMinPixels,
   required Snap snap,
   required TimeSignatureModel defaultTimeSignature,
   required List<TimeSignatureChangeModel> timeSignatureChanges,

--- a/lib/widgets/editors/shared/helpers/types.dart
+++ b/lib/widgets/editors/shared/helpers/types.dart
@@ -58,7 +58,7 @@ class Division {
   }
 }
 
-abstract class Snap {}
+sealed class Snap {}
 
 class BarSnap extends Snap {}
 

--- a/lib/widgets/main_window/main_window.dart
+++ b/lib/widgets/main_window/main_window.dart
@@ -52,7 +52,7 @@ class _MainWindowState extends State<MainWindow> {
           child: Container(
             color: const Color(0xFF2A3237),
             child: Padding(
-              padding: const EdgeInsets.all(6),
+              padding: const EdgeInsets.all(3),
               child: Observer(builder: (context) {
                 final tabs = store.projectOrder
                     .map<TabDef>(

--- a/lib/widgets/main_window/main_window.dart
+++ b/lib/widgets/main_window/main_window.dart
@@ -52,7 +52,7 @@ class _MainWindowState extends State<MainWindow> {
           child: Container(
             color: const Color(0xFF2A3237),
             child: Padding(
-              padding: const EdgeInsets.all(3),
+              padding: const EdgeInsets.all(6),
               child: Observer(builder: (context) {
                 final tabs = store.projectOrder
                     .map<TabDef>(

--- a/lib/widgets/main_window/main_window.dart
+++ b/lib/widgets/main_window/main_window.dart
@@ -18,7 +18,6 @@
 */
 
 import 'package:anthem/model/store.dart';
-import 'package:anthem/widgets/basic/shortcuts/shortcut_provider.dart';
 import 'package:anthem/widgets/main_window/main_window_controller.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter/widgets.dart';
@@ -47,38 +46,36 @@ class _MainWindowState extends State<MainWindow> {
 
     return Provider.value(
       value: controller,
-      child: ShortcutProvider(
-        child: ScreenOverlay(
-          child: Container(
-            color: const Color(0xFF2A3237),
-            child: Padding(
-              padding: const EdgeInsets.all(3),
-              child: Observer(builder: (context) {
-                final tabs = store.projectOrder
-                    .map<TabDef>(
-                      (projectID) => TabDef(
-                        id: projectID,
-                        title: store.projects[projectID]!.id,
-                      ),
-                    )
-                    .toList();
+      child: ScreenOverlay(
+        child: Container(
+          color: const Color(0xFF2A3237),
+          child: Padding(
+            padding: const EdgeInsets.all(3),
+            child: Observer(builder: (context) {
+              final tabs = store.projectOrder
+                  .map<TabDef>(
+                    (projectID) => TabDef(
+                      id: projectID,
+                      title: store.projects[projectID]!.id,
+                    ),
+                  )
+                  .toList();
 
-                return Column(
-                  children: [
-                    WindowHeader(
-                      selectedTabID: store.activeProjectID,
+              return Column(
+                children: [
+                  WindowHeader(
+                    selectedTabID: store.activeProjectID,
+                    tabs: tabs,
+                  ),
+                  Expanded(
+                    child: TabContentSwitcher(
                       tabs: tabs,
+                      selectedTabID: store.activeProjectID,
                     ),
-                    Expanded(
-                      child: TabContentSwitcher(
-                        tabs: tabs,
-                        selectedTabID: store.activeProjectID,
-                      ),
-                    ),
-                  ],
-                );
-              }),
-            ),
+                  ),
+                ],
+              );
+            }),
           ),
         ),
       ),

--- a/lib/widgets/main_window/tab_content_switcher.dart
+++ b/lib/widgets/main_window/tab_content_switcher.dart
@@ -17,12 +17,15 @@
   along with Anthem. If not, see <https://www.gnu.org/licenses/>.
 */
 
+import 'package:anthem/widgets/basic/shortcuts/shortcut_provider.dart';
 import 'package:flutter/widgets.dart';
 import 'main_window_controller.dart';
 
 import 'package:anthem/helpers/id.dart';
 import 'package:anthem/widgets/project/project.dart';
 
+/// This widget takes a list of tabs and a selected tab ID, and renders the
+/// active project based on it.
 class TabContentSwitcher extends StatelessWidget {
   final List<TabDef> tabs;
   final ID selectedTabID;
@@ -36,15 +39,18 @@ class TabContentSwitcher extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Stack(
-      children: tabs
-          .map(
-            (tab) => Positioned(
-              left: 0,
-              right: 0,
-              top: 0,
-              bottom: 0,
+      children: tabs.map(
+        (tab) {
+          final active = tab.id == selectedTabID;
+          return Positioned(
+            left: 0,
+            right: 0,
+            top: 0,
+            bottom: 0,
+            child: ShortcutProvider(
+              active: active,
               child: Visibility(
-                visible: tab.id == selectedTabID,
+                visible: active,
                 maintainAnimation: false,
                 maintainInteractivity: false,
                 maintainSemantics: false,
@@ -53,8 +59,9 @@ class TabContentSwitcher extends StatelessWidget {
                 child: Project(id: tab.id),
               ),
             ),
-          )
-          .toList(),
+          );
+        },
+      ).toList(),
     );
   }
 }

--- a/lib/widgets/main_window/window_header_engine_indicator.dart
+++ b/lib/widgets/main_window/window_header_engine_indicator.dart
@@ -44,11 +44,12 @@ class EngineIndicator extends StatelessObserverWidget {
         bottomLeft: Radius.circular(1),
         bottomRight: Radius.circular(1),
       ),
-      onPress: () {
+      onPress: () async {
         if (engineState != EngineState.stopped) {
           activeProject?.engine.stop();
         } else {
-          activeProject?.engine.start();
+          await activeProject?.engine.start();
+          activeProject?.createInEngine();
         }
       },
       contentBuilder: (context, color) {

--- a/lib/widgets/project/project.dart
+++ b/lib/widgets/project/project.dart
@@ -76,7 +76,7 @@ class _ProjectState extends State<Project> {
               projectID: widget.id,
             ),
             const SizedBox(
-              height: 6,
+              height: 3,
             ),
             Expanded(
               child: Observer(builder: (context) {
@@ -148,7 +148,7 @@ class _ProjectState extends State<Project> {
               }),
             ),
             const SizedBox(
-              height: 6,
+              height: 3,
             ),
             const ProjectFooter(),
           ],

--- a/lib/widgets/project/project.dart
+++ b/lib/widgets/project/project.dart
@@ -76,7 +76,7 @@ class _ProjectState extends State<Project> {
               projectID: widget.id,
             ),
             const SizedBox(
-              height: 3,
+              height: 6,
             ),
             Expanded(
               child: Observer(builder: (context) {
@@ -148,7 +148,7 @@ class _ProjectState extends State<Project> {
               }),
             ),
             const SizedBox(
-              height: 3,
+              height: 6,
             ),
             const ProjectFooter(),
           ],

--- a/lib/widgets/project/project.dart
+++ b/lib/widgets/project/project.dart
@@ -69,7 +69,8 @@ class _ProjectState extends State<Project> {
       child: ShortcutConsumer(
         id: 'project',
         global: true,
-        handler: controller.onShortcut,
+        shortcutHandler: controller.onShortcut,
+        rawKeyHandler: controller.onKey,
         child: Column(
           children: [
             ProjectHeader(

--- a/lib/widgets/project/project_controller.dart
+++ b/lib/widgets/project/project_controller.dart
@@ -24,6 +24,7 @@ import 'package:anthem/model/pattern/pattern.dart';
 import 'package:anthem/model/project.dart';
 import 'package:anthem/widgets/basic/shortcuts/shortcut_provider_controller.dart';
 import 'package:anthem/widgets/project/project_view_model.dart';
+import 'package:anthem/widgets/project/typing_keyboard_piano_handler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -122,6 +123,34 @@ class ProjectController {
             LogicalKeyboardKey.shift, LogicalKeyboardKey.keyZ))) {
       redo();
     }
+  }
+
+  bool onKey(KeyEvent event) {
+    if (event is KeyRepeatEvent) return false;
+
+    final key = event.logicalKey;
+
+    if (viewModel.keyboardPianoEnabled && isTypingPianoKey(key)) {
+      final note = getMidiNoteFromKeyboardKey(key)!;
+
+      if (event is KeyDownEvent) {
+        project.engine.projectApi.noteOn(
+          note: note,
+          editPointer: project
+              .song.arrangements[project.song.activeArrangementID]!.editPointer,
+        );
+      } else {
+        project.engine.projectApi.noteOff(
+          note: note,
+          editPointer: project
+              .song.arrangements[project.song.activeArrangementID]!.editPointer,
+        );
+      }
+
+      return true;
+    }
+
+    return false;
   }
 
   void setHintText(String text) {

--- a/lib/widgets/project/project_header.dart
+++ b/lib/widgets/project/project_header.dart
@@ -24,7 +24,9 @@ import 'package:anthem/widgets/basic/menu/menu.dart';
 import 'package:anthem/widgets/basic/menu/menu_model.dart';
 import 'package:anthem/widgets/main_window/main_window_controller.dart';
 import 'package:anthem/widgets/project/project_controller.dart';
+import 'package:anthem/widgets/project/project_view_model.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:provider/provider.dart';
 
 import '../basic/icon.dart';
@@ -39,6 +41,7 @@ class ProjectHeader extends StatelessWidget {
     final menuController = MenuController();
     final mainWindowController = context.read<MainWindowController>();
     final projectController = context.read<ProjectController>();
+    final projectViewModel = context.read<ProjectViewModel>();
 
     return Container(
       height: 40,
@@ -125,6 +128,21 @@ class ProjectHeader extends StatelessWidget {
                 projectController.redo();
               },
               hint: 'Redo (Ctrl+Shift+Z)',
+            ),
+            const SizedBox(width: 4),
+            Observer(
+              builder: (context) {
+                return Button(
+                  toggleState: projectViewModel.keyboardPianoEnabled,
+                  icon: Icons.mainToolbar.typingKeyboardToPianoKeyboard,
+                  onPress: () {
+                    projectViewModel.keyboardPianoEnabled =
+                        !projectViewModel.keyboardPianoEnabled;
+                  },
+                  hint:
+                      'Send notes to the active instrument with the typing keyboard',
+                );
+              },
             ),
           ],
         ),

--- a/lib/widgets/project/project_view_model.dart
+++ b/lib/widgets/project/project_view_model.dart
@@ -27,4 +27,8 @@ class ProjectViewModel = _ProjectViewModel with _$ProjectViewModel;
 abstract class _ProjectViewModel with Store {
   @observable
   String hintText = '';
+
+  // We should probably persist this between sessions
+  @observable
+  bool keyboardPianoEnabled = false;
 }

--- a/lib/widgets/project/typing_keyboard_piano_handler.dart
+++ b/lib/widgets/project/typing_keyboard_piano_handler.dart
@@ -1,0 +1,68 @@
+/*
+  Copyright (C) 2023 Joshua Wade
+
+  This file is part of Anthem.
+
+  Anthem is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Anthem is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Anthem. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import 'package:flutter/services.dart';
+
+/// List of keys and their corresponding MIDI note numbers
+final _keySet = <LogicalKeyboardKey, int>{
+  // Lower octave
+  LogicalKeyboardKey.keyZ: 48,
+  LogicalKeyboardKey.keyS: 49,
+  LogicalKeyboardKey.keyX: 50,
+  LogicalKeyboardKey.keyD: 51,
+  LogicalKeyboardKey.keyC: 52,
+  LogicalKeyboardKey.keyV: 53,
+  LogicalKeyboardKey.keyG: 54,
+  LogicalKeyboardKey.keyB: 55,
+  LogicalKeyboardKey.keyH: 56,
+  LogicalKeyboardKey.keyN: 57,
+  LogicalKeyboardKey.keyJ: 58,
+  LogicalKeyboardKey.keyM: 59,
+  LogicalKeyboardKey.comma: 60,
+  LogicalKeyboardKey.keyL: 61,
+  LogicalKeyboardKey.period: 62,
+  LogicalKeyboardKey.semicolon: 63,
+  LogicalKeyboardKey.slash: 64,
+
+  // Upper octave (60 is middle C)
+  LogicalKeyboardKey.keyQ: 60,
+  LogicalKeyboardKey.digit2: 61,
+  LogicalKeyboardKey.keyW: 62,
+  LogicalKeyboardKey.digit3: 63,
+  LogicalKeyboardKey.keyE: 64,
+  LogicalKeyboardKey.keyR: 65,
+  LogicalKeyboardKey.digit5: 66,
+  LogicalKeyboardKey.keyT: 67,
+  LogicalKeyboardKey.digit6: 68,
+  LogicalKeyboardKey.keyY: 69,
+  LogicalKeyboardKey.digit7: 70,
+  LogicalKeyboardKey.keyU: 71,
+  LogicalKeyboardKey.keyI: 72,
+  LogicalKeyboardKey.digit9: 73,
+  LogicalKeyboardKey.keyO: 74,
+  LogicalKeyboardKey.digit0: 75,
+  LogicalKeyboardKey.keyP: 76,
+  LogicalKeyboardKey.bracketLeft: 77,
+  LogicalKeyboardKey.equal: 78,
+  LogicalKeyboardKey.bracketRight: 79,
+};
+
+/// Returns true if a given key is part of the typing keyboard piano
+bool isTypingPianoKey(LogicalKeyboardKey key) => _keySet.containsKey(key);
+int? getMidiNoteFromKeyboardKey(LogicalKeyboardKey key) => _keySet[key];

--- a/lib/widgets/project_details/pattern_detail_view.dart
+++ b/lib/widgets/project_details/pattern_detail_view.dart
@@ -34,6 +34,11 @@ class PatternDetailView extends StatelessObserverWidget {
   @override
   Widget build(BuildContext context) {
     final project = Provider.of<ProjectModel>(context);
+
+    if (project.selectedDetailView is! PatternDetailViewKind) {
+      return const SizedBox();
+    }
+
     final patternID =
         (project.selectedDetailView as PatternDetailViewKind).patternID;
     final pattern = project.song.patterns[patternID]!;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,42 +5,34 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "98d1d33ed129b372846e862de23a0fc365745f4d7b5e786ce667fcbbb7ac5c07"
+      sha256: "405666cd3cf0ee0a48d21ec67e65406aad2c726d9fa58840d3375e7bdcd32a07"
       url: "https://pub.dev"
     source: hosted
-    version: "55.0.0"
+    version: "60.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "881348aed9b0b425882c97732629a6a31093c8ff20fc4b3b03fb9d3d50a3a126"
+      sha256: "1952250bd005bacb895a01bf1b4dc00e3ba1c526cf47dca54dfe24979c65f5b3"
       url: "https://pub.dev"
     source: hosted
-    version: "5.7.1"
-  archive:
-    dependency: transitive
-    description:
-      name: archive
-      sha256: "80e5141fafcb3361653ce308776cfd7d45e6e9fbb429e14eec571382c0c5fecb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.3.2"
+    version: "5.12.0"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: "4cab82a83ffef80b262ddedf47a0a8e56ee6fbf7fe21e6e768b02792034dd440"
+      sha256: c372bb384f273f0c2a8aaaa226dad84dc27c8519a691b888725dec59518ad53a
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   bitsdojo_window:
     dependency: "direct main"
     description:
@@ -93,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "3fbda25365741f8251b39f3917fb3c8e286a96fd068a5a242e11c2012d495777"
+      sha256: "43865b79fbb78532e4bff7c33087aa43b1d488c4fdef014eaef568af6d8016dc"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.0"
   build_config:
     dependency: transitive
     description:
@@ -109,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "757153e5d9cd88253cb13f28c2fb55a537dc31fefd98137549895b5beb7c6169"
+      sha256: "5f02d73eb2ba16483e693f80bee4f088563a820e47d1027d4cdfe62b5bb43e65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "4.0.0"
   build_resolvers:
     dependency: transitive
     description:
@@ -125,18 +117,18 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b0a8a7b8a76c493e85f1b84bffa0588859a06197863dba8c9036b15581fd9727
+      sha256: "220ae4553e50d7c21a17c051afc7b183d28a24a420502e842f303f8e4e6edced"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.4"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "14febe0f5bac5ae474117a36099b4de6f1dbc52df6c5e55534b3da9591bf4292"
+      sha256: "30859c90e9ddaccc484f56303931f477b1f1ba2bab74aa32ed5d6ce15870f8cf"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.7"
+    version: "7.2.8"
   built_collection:
     dependency: transitive
     description:
@@ -149,26 +141,26 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "31b7c748fd4b9adf8d25d72a4c4a59ef119f12876cf414f94f8af5131d5fa2b0"
+      sha256: "2f17434bd5d52a26762043d6b43bb53b3acd029b4d9071a329f46d67ef297e6d"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.4"
+    version: "8.5.0"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   clock:
     dependency: transitive
     description:
@@ -189,10 +181,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   convert:
     dependency: transitive
     description:
@@ -205,18 +197,18 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "6d691edde054969f0e0f26abb1b30834b5138b963793e56f69d3a9a4435e6352"
+      sha256: f4f1f73ab3fd2afcbcca165ee601fe980d966af6a21b5970c6c9376955c528ad
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   fake_async:
     dependency: transitive
     description:
@@ -229,10 +221,10 @@ packages:
     dependency: "direct main"
     description:
       name: ffi
-      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      sha256: ed5337a5660c506388a9f012be0288fb38b49020ce2b45fe1f8b8323fe429f99
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   file:
     dependency: transitive
     description:
@@ -245,10 +237,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: d8e9ca7e5d1983365c277f12c21b4362df6cf659c99af146ad4d04eb33033013
+      sha256: b85eb92b175767fdaa0c543bf3b0d1f610fe966412ea72845fe5ba7801e763ff
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.6"
+    version: "5.2.10"
   fixnum:
     dependency: transitive
     description:
@@ -295,18 +287,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: c224ac897bed083dabf11f238dd11a239809b446740be0c2044608c50029ffdf
+      sha256: "96af49aa6b57c10a312106ad6f71deed5a754029c24789bbf620ba784f0bd0b0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.14"
   flutter_svg:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: "12006889e2987c549c4c1ec1a5ba4ec4b24d34d2469ee5f9476c926dcecff266"
+      sha256: f991fdb1533c3caeee0cdc14b04f50f0c3916f0dbcbc05237ccbe4e3c6b93f3f
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -358,10 +350,10 @@ packages:
     dependency: transitive
     description:
       name: graphs
-      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
+      sha256: "772db3d53d23361d4ffcf5a9bb091cf3ee9b22f2be52cd107cd7a2683a89ba0e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -395,34 +387,34 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.8.1"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: dadc08bd61f72559f938dd08ec20dbfec6c709bba83515085ea943d2078d187a
+      sha256: "43793352f90efa5d8b251893a63d767b2f7c833120e3cc02adad55eefec04dc7"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "6.6.2"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      sha256: "6b0206b0bf4f04961fc5438198ccb3a885685cd67d4d4a32cc20ad7f8adbe015"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   logging:
     dependency: transitive
     description:
@@ -435,10 +427,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -451,10 +443,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -467,18 +459,18 @@ packages:
     dependency: "direct main"
     description:
       name: mobx
-      sha256: "6738620307a424d2c9ad8b873f4dce391c44e9135eb4e75668ac8202fec7a9b8"
+      sha256: "0afcf88b3ee9d6819890bf16c11a727fc8c62cf736fda8e5d3b9b4eace4e62ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   mobx_codegen:
     dependency: "direct dev"
     description:
       name: mobx_codegen
-      sha256: "86122e410d8ea24dda0c69adb5c2a6ccadd5ce02ad46e144764e0d0184a06181"
+      sha256: d4beb9cea4b7b014321235f8fdc7c2193ee0fe1d1198e9da7403f8bc85c4407c
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.3.0"
   nanoid:
     dependency: "direct main"
     description:
@@ -507,10 +499,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_parsing:
     dependency: transitive
     description:
@@ -523,10 +515,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "49392a45ced973e8d94a85fdb21293fbb40ba805fc49f2965101ae748a3683b4"
+      sha256: cb3798bef7fc021ac45b308f4b51208a152792445cce0448c9a4ba5879dd8750
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "5.4.0"
   platform:
     dependency: transitive
     description:
@@ -571,34 +563,34 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: ec85d7d55339d85f44ec2b682a82fea340071e8978257e5a43e69f79e98ef50c
+      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.3"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -608,10 +600,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: c2bea18c95cfa0276a366270afaa2850b09b4a76db95d546f3d003dcc7011298
+      sha256: "373f96cf5a8744bc9816c1ff41cf5391bbdbe3d7a96fe98c622b6738a8a7bd33"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.7"
+    version: "1.3.2"
   source_helper:
     dependency: transitive
     description:
@@ -680,10 +672,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   timing:
     dependency: transitive
     description:
@@ -696,34 +688,34 @@ packages:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   vector_graphics:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "4cf8e60dbe4d3a693d37dff11255a172594c0793da542183cbfe7fe978ae4aaa"
+      sha256: "59a230f8bf37dd8b077335d1d64d895bccef0fb14f50730e3d79e8990bf3ed2b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.5+1"
   vector_graphics_codec:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: "278ad5f816f58b1967396d1f78ced470e3e58c9fe4b27010102c0a595c764468"
+      sha256: "40781fe91c6d10a617c0289f7ec16cdb2d85a7f3654af2778c6d0adbf3bf45a3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.5+1"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "0bf61ad56e6fd6688a2865d3ceaea396bc6a0a90ea0d7ad5049b1b76c09d6163"
+      sha256: "6ca1298b70edcc3486fdb14032f1a186a593f1b5f6b5e82fb10febddcb1c61bb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.5+1"
   vector_math:
     dependency: "direct main"
     description:
@@ -736,58 +728,58 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: e7fb6c2282f7631712b69c19d1bff82f3767eea33a2321c14fa59ad67ea391c7
+      sha256: f6deed8ed625c52864792459709183da231ebf66ff0cf09e69b573227c377efe
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.0"
+    version: "11.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: ef67178f0cc7e32c1494645b11639dd1335f1d18814aa8435113a92e9ef9d841
+      sha256: "3c923e918918feeb90c4c9fdf1fe39220fa4c0e8e2c0fffaded174498ef86c49"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: c9ebe7ee4ab0c2194e65d3a07d8c54c5d00bb001b76081c4a04cdb8448b59e46
+      sha256: a6f0236dbda0f63aa9a25ad1ff9a9d8a4eaaa5012da0dc59d21afdb1dc361ca4
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.4"
   xml:
     dependency: transitive
     description:
       name: xml
-      sha256: "979ee37d622dec6365e2efa4d906c37470995871fe9ae080d967e192d88286b5"
+      sha256: "5bc72e1e45e941d825fd7468b9b4cc3b9327942649aeb6fc5cdbf135f0a86e84"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.2"
+    version: "6.3.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=3.7.0-0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
This PR allows live MIDI messages to be sent from the UI to the engine. You can now enable the typing keyboard piano and play notes on the first loaded instrument.

There are some caveats to this. The Anthem UI does not yet track an active instrument, so MIDI notes are sent to the first loaded instrument. This also only supports happy path, and there are likely a couple edge cases that will cause the engine to crash.

Other notable changes:
- The engine now hooks into JUCE's event loop, meaning UI messages are safely processed on the main thread instead of being handled on Anthem's message thread. This fixes some stability issues.
- VST plugins are now loaded correctly using Tracktion Engine, instead of just being loaded with JUCE. Tracktion Engine does still wrap JUCE's plugin hosting system, but Tracktion Engine is now able to process audio from loaded plugins.
- Dart and Flutter have been upgraded to 3.0 and 3.10 respectively, and a couple things have been refactored to take advantage of the new features in Dart 3.