### PR TITLE
Fixup and update GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -266,6 +266,12 @@ jobs:
       # --------------------------------------------------------------
       # Deploy web build
       # --------------------------------------------------------------
+      - name: Install Node.js
+        if: matrix.arch == 'wasm'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          
       - name: Deploy web build to CloudFlare Pages
         if: matrix.arch == 'wasm'
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,10 +33,10 @@ jobs:
     steps:
       - name: Set up Emscripten
         if: matrix.arch == 'wasm'
-        uses: mymindstorm/setup-emsdk@v14
+        uses: emscripten-core/setup-emsdk@v16
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -233,7 +233,7 @@ jobs:
       # --------------------------------------------------------------
       - name: Upload artifact (Windows)
         if: contains(matrix.os, 'windows')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: anthem-windows-${{ matrix.arch }}
           # As of writing, Flutter on Windows currently builds x64, as Dart does
@@ -248,7 +248,7 @@ jobs:
       # --------------------------------------------------------------
       - name: Upload artifact (Linux)
         if: contains(matrix.os, 'ubuntu') && matrix.arch != 'wasm'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: anthem-linux-${{ matrix.arch }}
           path: ${{ github.workspace }}/${{ matrix.arch == 'x64' && 'build/linux/x64/release/bundle' || 'build/linux/arm64/release/bundle' }}
@@ -258,7 +258,7 @@ jobs:
       # --------------------------------------------------------------
       - name: Upload artifact (macOS)
         if: contains(matrix.os, 'macos')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: anthem-macos-${{ matrix.arch }}
           path: ${{ github.workspace }}/build/macos/Build/Products/Release/Anthem.app

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -241,7 +241,7 @@ jobs:
           # are built as x64, and are output to the x64 folder. If (hopefully
           # when) this changes, the path here would look like the Linux path
           # below.
-          path: ${{ github.workspace }}/build/windows/x64/runner/Release
+          path: build/windows/x64/runner/Release
 
       # --------------------------------------------------------------
       # Upload artifacts (Linux)
@@ -251,7 +251,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: anthem-linux-${{ matrix.arch }}
-          path: ${{ github.workspace }}/${{ matrix.arch == 'x64' && 'build/linux/x64/release/bundle' || 'build/linux/arm64/release/bundle' }}
+          path: build/linux/${{ matrix.arch }}/release/bundle
 
       # --------------------------------------------------------------
       # Upload artifacts (macOS)
@@ -263,7 +263,7 @@ jobs:
           name: anthem-macos-${{ matrix.arch }}
           # https://github.com/actions/upload-artifact#upload-using-multiple-paths-and-exclusions
           # If a wildcard pattern is used, the path hierarchy will start with the first wildcard pattern
-          path: ${{ github.workspace }}/build/macos/Build/Products/Release/*.app
+          path: build/macos/Build/Products/Release/*.app
 
       # --------------------------------------------------------------
       # Deploy web build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -261,7 +261,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: anthem-macos-${{ matrix.arch }}
-          path: ${{ github.workspace }}/build/macos/Build/Products/Release/Anthem.app
+          path: ${{ github.workspace }}/build/macos/Build/Products/Release
 
       # --------------------------------------------------------------
       # Deploy web build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -261,7 +261,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: anthem-macos-${{ matrix.arch }}
-          path: ${{ github.workspace }}/build/macos/Build/Products/Release
+          # https://github.com/actions/upload-artifact#upload-using-multiple-paths-and-exclusions
+          # If a wildcard pattern is used, the path hierarchy will start with the first wildcard pattern
+          path: ${{ github.workspace }}/build/macos/Build/Products/Release/*.app
 
       # --------------------------------------------------------------
       # Deploy web build


### PR DESCRIPTION
- Install Node.js 24 in the WASM case to fix the broken upload step
- Update third-party actions to their latest versions
- Fix macOS artifact upload path so it only includes Anthem.app
- Remove redundant `${{ github.workspace }}` prefix in upload paths
- Make Linux artifact upload path more readable