### PR TITLE
Split build and lint CI workflows

### DIFF
--- a/.github/actions/install-prereqs/action.yml
+++ b/.github/actions/install-prereqs/action.yml
@@ -1,0 +1,58 @@
+name: Install prerequisites
+description: Set up the build environment
+runs:
+  using: composite
+  steps:
+    - name: Install build tools (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt install -y ca-certificates gnupg lsb-release software-properties-common wget
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+        source /etc/os-release
+        llvm_codename="${UBUNTU_CODENAME:-$VERSION_CODENAME}"
+        sudo add-apt-repository -y "deb https://apt.llvm.org/${llvm_codename}/ llvm-toolchain-${llvm_codename}-22 main"
+        sudo apt update
+        sudo apt install -y \
+          ninja-build llvm-22 clang-22 clang-format-22 clang-tidy-22 libx11-dev \
+          libxrandr-dev libxinerama-dev libxcursor-dev libfreetype-dev mesa-common-dev \
+          libasound2-dev freeglut3-dev libxcomposite-dev libgtk-3-dev libasound2-dev \
+          libwebkit2gtk-4.1-dev libcurl4-openssl-dev
+        echo "ANTHEM_LLVM_BIN=/usr/lib/llvm-22/bin" >> "$GITHUB_ENV"
+        echo "/usr/lib/llvm-22/bin" >> "$GITHUB_PATH"
+
+    - name: Install build tools (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        brew install llvm@22 ninja
+        echo "ANTHEM_LLVM_BIN=$(brew --prefix llvm@22)/bin" >> $GITHUB_ENV
+        echo "$(brew --prefix llvm@22)/bin" >> $GITHUB_PATH
+
+    - name: Install build tools (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        choco install llvm --version=22.1.0 -y
+        choco install ninja -y
+        Add-Content $env:GITHUB_ENV 'ANTHEM_LLVM_BIN=C:\Program Files\LLVM\bin'
+        Add-Content $env:GITHUB_PATH 'C:\Program Files\LLVM\bin'
+        Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\bin'
+
+    - name: Print LLVM tool versions
+      shell: bash
+      run: |
+        clang --version
+        clang-format --version
+        clang-tidy --version
+
+    - name: Clone Flutter
+      shell: bash
+      run: |
+        git clone --branch stable https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
+        echo "$RUNNER_TEMP/flutter/bin" >> $GITHUB_PATH
+
+    - name: Install Flutter
+      shell: bash
+      run: flutter doctor

--- a/.github/actions/shared-init/action.yml
+++ b/.github/actions/shared-init/action.yml
@@ -1,5 +1,5 @@
-name: Install prerequisites
-description: Set up the build environment
+name: Initialize project
+description: Install build tools, check out the code, and run code generation
 runs:
   using: composite
   steps:
@@ -56,3 +56,19 @@ runs:
     - name: Install Flutter
       shell: bash
       run: flutter doctor
+
+    - name: Check out code
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+
+    - name: Get Dart dependencies
+      shell: bash
+      run: |
+        flutter pub get
+        (cd codegen && flutter pub get)
+        (cd tools/anthem_analyzer_plugin && dart pub get)
+
+    - name: Run code generation
+      shell: bash
+      run: dart run anthem:cli codegen generate --explicit-format-for-ci

--- a/.github/actions/shared-init/action.yml
+++ b/.github/actions/shared-init/action.yml
@@ -57,11 +57,6 @@ runs:
       shell: bash
       run: flutter doctor
 
-    - name: Check out code
-      uses: actions/checkout@v6
-      with:
-        submodules: recursive
-
     - name: Get Dart dependencies
       shell: bash
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,9 +38,6 @@ jobs:
         with:
           submodules: recursive
 
-      # --------------------------------------------------------------
-      # Install dependencies (Linux only)
-      # --------------------------------------------------------------
       - name: Install apt dependencies
         if: contains(matrix.os, 'ubuntu')
         run: |
@@ -59,9 +56,6 @@ jobs:
           echo "ANTHEM_LLVM_BIN=/usr/lib/llvm-22/bin" >> "$GITHUB_ENV"
           echo "/usr/lib/llvm-22/bin" >> "$GITHUB_PATH"
 
-      # --------------------------------------------------------------
-      # Install dependencies (Windows only)
-      # --------------------------------------------------------------
       - name: Install Windows dependencies
         if: contains(matrix.os, 'windows')
         run: |
@@ -71,9 +65,6 @@ jobs:
           Add-Content $env:GITHUB_PATH 'C:\Program Files\LLVM\bin'
           Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\bin'
 
-      # --------------------------------------------------------------
-      # Install dependencies (macOS only)
-      # --------------------------------------------------------------
       - name: Install macOS dependencies
         if: contains(matrix.os, 'macos')
         run: |
@@ -81,9 +72,6 @@ jobs:
           echo "ANTHEM_LLVM_BIN=$(brew --prefix llvm@22)/bin" >> $GITHUB_ENV
           echo "$(brew --prefix llvm@22)/bin" >> $GITHUB_PATH
 
-      # --------------------------------------------------------------
-      # Print LLVM tool versions
-      # --------------------------------------------------------------
       - name: Print LLVM tool versions
         if: matrix.arch != 'wasm'
         run: |
@@ -91,33 +79,21 @@ jobs:
           clang-format --version
           clang-tidy --version
 
-      # --------------------------------------------------------------
-      # Clone + set up Flutter (Windows)
-      # --------------------------------------------------------------
       - name: Clone Flutter (Windows)
         if: contains(matrix.os, 'windows')
         run: |
           git clone --branch stable https://github.com/flutter/flutter.git $env:RUNNER_TEMP\flutter
           Add-Content $env:GITHUB_PATH "$env:RUNNER_TEMP\flutter\bin"
 
-      # --------------------------------------------------------------
-      # Clone + set up Flutter (Linux, macOS)
-      # --------------------------------------------------------------
       - name: Clone Flutter (Linux, macOS)
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         run: |
           git clone --branch stable https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
           echo "$RUNNER_TEMP/flutter/bin" >> $GITHUB_PATH
 
-      # --------------------------------------------------------------
-      # Flutter doctor
-      # --------------------------------------------------------------
       - name: Install Flutter
         run: flutter doctor
       
-      # --------------------------------------------------------------
-      # Get dependencies
-      # --------------------------------------------------------------
       - name: Get root dependencies
         run: flutter pub get
 
@@ -129,46 +105,28 @@ jobs:
         working-directory: tools/anthem_analyzer_plugin
         run: dart pub get
 
-      # --------------------------------------------------------------
-      # Run code generation
-      # --------------------------------------------------------------
       - name: Run code generation
         run: dart run anthem:cli codegen generate --explicit-format-for-ci
 
-      # --------------------------------------------------------------
-      # Check formatting
-      # --------------------------------------------------------------
       - name: Format code
         run: dart format . --set-exit-if-changed -o none
 
-      # --------------------------------------------------------------
-      # Lint (Windows)
-      # --------------------------------------------------------------
       - name: Lint code (Windows)
         if: contains(matrix.os, 'windows')
         run: |
           mkdir assets\engine
           dart analyze --fatal-infos
       
-      # --------------------------------------------------------------
-      # Lint (Linux, macOS)
-      # --------------------------------------------------------------
       - name: Lint code (Linux, macOS)
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         run: |
           mkdir -p assets/engine
           dart analyze --fatal-infos
 
-      # --------------------------------------------------------------
-      # Check engine C++ formatting
-      # --------------------------------------------------------------
       - name: Check engine C++ formatting
         if: matrix.arch != 'wasm'
         run: dart run anthem:cli engine format --check
 
-      # --------------------------------------------------------------
-      # Build engine (desktop)
-      # --------------------------------------------------------------
       - name: Build engine (desktop)
         if: matrix.arch != 'wasm'
         run: dart run anthem:cli engine build --release
@@ -177,58 +135,34 @@ jobs:
         if: matrix.arch == 'wasm'
         run: dart run anthem:cli engine build --release --wasm
 
-      # --------------------------------------------------------------
-      # Lint engine C++ with clang-tidy
-      # --------------------------------------------------------------
       - name: Lint engine C++ with clang-tidy
         if: matrix.arch != 'wasm'
         run: dart run anthem:cli engine lint
 
-      # --------------------------------------------------------------
-      # Engine unit tests
-      # --------------------------------------------------------------
       - name: Run engine unit tests
         if: matrix.arch != 'wasm'
         run: dart run anthem:cli engine unit-test
 
-      # --------------------------------------------------------------
-      # Flutter unit + integration tests
-      # --------------------------------------------------------------
       - name: Run Flutter tests
         if: matrix.arch != 'wasm'
         run: dart run anthem:cli flutter_test
 
-      # --------------------------------------------------------------
-      # Build Flutter (Windows)
-      # --------------------------------------------------------------
       - name: Build Flutter (Windows)
         if: contains(matrix.os, 'windows')
         run: flutter build windows --verbose --release
         
-      # --------------------------------------------------------------
-      # Build Flutter (Linux)
-      # --------------------------------------------------------------
       - name: Build Flutter (Linux)
         if: contains(matrix.os, 'ubuntu') && matrix.arch != 'wasm'
         run: flutter build linux --verbose --release
       
-      # --------------------------------------------------------------
-      # Build Flutter (macOS)
-      # --------------------------------------------------------------
       - name: Build Flutter (macOS)
         if: contains(matrix.os, 'macos')
         run: flutter build macos --verbose --release
 
-      # --------------------------------------------------------------
-      # Build Flutter (WASM)
-      # --------------------------------------------------------------
       - name: Build Flutter (WASM)
         if: matrix.arch == 'wasm'
         run: flutter build web --verbose --release --wasm
 
-      # --------------------------------------------------------------
-      # Upload artifacts (Windows)
-      # --------------------------------------------------------------
       - name: Upload artifact (Windows)
         if: contains(matrix.os, 'windows')
         uses: actions/upload-artifact@v7
@@ -241,9 +175,6 @@ jobs:
           # below.
           path: build/windows/x64/runner/Release
 
-      # --------------------------------------------------------------
-      # Upload artifacts (Linux)
-      # --------------------------------------------------------------
       - name: Upload artifact (Linux)
         if: contains(matrix.os, 'ubuntu') && matrix.arch != 'wasm'
         uses: actions/upload-artifact@v7
@@ -251,9 +182,6 @@ jobs:
           name: anthem-linux-${{ matrix.arch }}
           path: build/linux/${{ matrix.arch }}/release/bundle
 
-      # --------------------------------------------------------------
-      # Upload artifacts (macOS)
-      # --------------------------------------------------------------
       - name: Upload artifact (macOS)
         if: contains(matrix.os, 'macos')
         uses: actions/upload-artifact@v7
@@ -263,9 +191,6 @@ jobs:
           # If a wildcard pattern is used, the path hierarchy will start with the first wildcard pattern
           path: build/macos/Build/Products/Release/*.app
 
-      # --------------------------------------------------------------
-      # Deploy web build
-      # --------------------------------------------------------------
       - name: Install Node.js
         if: matrix.arch == 'wasm'
         uses: actions/setup-node@v6

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Build Anthem
+name: Build
 
 on:
   push:
@@ -19,52 +19,19 @@ jobs:
             arch: arm64
 
     steps:
+      - name: Install prerequisites
+        uses: ./.github/actions/install-prereqs
+
       - name: Check out code
         uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - name: Install dependencies
+      - name: Get Dart dependencies
         run: |
-          sudo apt update
-          sudo apt install -y ca-certificates gnupg lsb-release software-properties-common wget
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
-          source /etc/os-release
-          llvm_codename="${UBUNTU_CODENAME:-$VERSION_CODENAME}"
-          sudo add-apt-repository -y "deb https://apt.llvm.org/${llvm_codename}/ llvm-toolchain-${llvm_codename}-22 main"
-          sudo apt update
-          sudo apt install -y ninja-build llvm-22 clang-22 clang-format-22 clang-tidy-22 libx11-dev libxrandr-dev \
-                             libxinerama-dev libxcursor-dev libfreetype-dev \
-                             mesa-common-dev libasound2-dev freeglut3-dev \
-                             libxcomposite-dev libgtk-3-dev libasound2-dev \
-                             libwebkit2gtk-4.1-dev libcurl4-openssl-dev
-          echo "ANTHEM_LLVM_BIN=/usr/lib/llvm-22/bin" >> "$GITHUB_ENV"
-          echo "/usr/lib/llvm-22/bin" >> "$GITHUB_PATH"
-
-      - name: Print LLVM tool versions
-        run: |
-          clang --version
-          clang-format --version
-          clang-tidy --version
-
-      - name: Clone Flutter
-        run: |
-          git clone --branch stable https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
-          echo "$RUNNER_TEMP/flutter/bin" >> $GITHUB_PATH
-
-      - name: Install Flutter
-        run: flutter doctor
-
-      - name: Get root dependencies
-        run: flutter pub get
-
-      - name: Get codegen dependencies
-        working-directory: codegen
-        run: flutter pub get
-
-      - name: Get analyzer plugin dependencies
-        working-directory: tools/anthem_analyzer_plugin
-        run: dart pub get
+          flutter pub get
+          (cd codegen && flutter pub get)
+          (cd tools/anthem_analyzer_plugin && dart pub get)
 
       - name: Run code generation
         run: dart run anthem:cli codegen generate --explicit-format-for-ci
@@ -101,6 +68,69 @@ jobs:
           name: anthem-linux-${{ matrix.arch }}
           path: build/linux/${{ matrix.arch }}/release/bundle
 
+  build-macos:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            arch: arm64
+          - os: macos-15-intel
+            arch: x64
+
+    steps:
+      - name: Install prerequisites
+        uses: ./.github/actions/install-prereqs
+
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Get Dart dependencies
+        run: |
+          flutter pub get
+          (cd codegen && flutter pub get)
+          (cd tools/anthem_analyzer_plugin && dart pub get)
+
+      - name: Run code generation
+        run: dart run anthem:cli codegen generate --explicit-format-for-ci
+
+      - name: Format code
+        run: dart format . --set-exit-if-changed -o none
+
+      - name: Lint code
+        run: |
+          mkdir -p assets/engine
+          dart analyze --fatal-infos
+
+      - name: Check engine C++ formatting
+        run: dart run anthem:cli engine format --check
+
+      - name: Build engine
+        run: dart run anthem:cli engine build --release
+
+      - name: Lint engine C++ with clang-tidy
+        run: dart run anthem:cli engine lint
+
+      - name: Run engine unit tests
+        run: dart run anthem:cli engine unit-test
+
+      - name: Run Flutter tests
+        run: dart run anthem:cli flutter_test
+
+      - name: Build Flutter
+        run: flutter build macos --verbose --release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: anthem-macos-${{ matrix.arch }}
+          # https://github.com/actions/upload-artifact#upload-using-multiple-paths-and-exclusions
+          # If a wildcard pattern is used, the path hierarchy will start with the first wildcard pattern
+          path: build/macos/Build/Products/Release/*.app
+
   build-windows:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -113,43 +143,21 @@ jobs:
             arch: arm64
 
     steps:
+      - name: Install prerequisites
+        uses: ./.github/actions/install-prereqs
+
       - name: Check out code
         uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - name: Install dependencies
-        run: |
-          choco install llvm --version=22.1.0 -y
-          choco install ninja -y
-          Add-Content $env:GITHUB_ENV 'ANTHEM_LLVM_BIN=C:\Program Files\LLVM\bin'
-          Add-Content $env:GITHUB_PATH 'C:\Program Files\LLVM\bin'
-          Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\bin'
-
-      - name: Print LLVM tool versions
-        run: |
-          clang --version
-          clang-format --version
-          clang-tidy --version
-
-      - name: Clone Flutter
-        run: |
-          git clone --branch stable https://github.com/flutter/flutter.git $env:RUNNER_TEMP\flutter
-          Add-Content $env:GITHUB_PATH "$env:RUNNER_TEMP\flutter\bin"
-
-      - name: Install Flutter
-        run: flutter doctor
-
       - name: Get root dependencies
-        run: flutter pub get
-
-      - name: Get codegen dependencies
-        working-directory: codegen
-        run: flutter pub get
-
-      - name: Get analyzer plugin dependencies
-        working-directory: tools/anthem_analyzer_plugin
-        run: dart pub get
+        run: |
+          flutter pub get
+          cd codegen
+          flutter pub get
+          cd ..\tools\anthem_analyzer_plugin
+          dart pub get
 
       - name: Run code generation
         run: dart run anthem:cli codegen generate --explicit-format-for-ci
@@ -191,91 +199,6 @@ jobs:
           # below.
           path: build/windows/x64/runner/Release
 
-  build-macos:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-latest
-            arch: arm64
-          - os: macos-15-intel
-            arch: x64
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Install dependencies
-        run: |
-          brew install llvm@22 ninja
-          echo "ANTHEM_LLVM_BIN=$(brew --prefix llvm@22)/bin" >> $GITHUB_ENV
-          echo "$(brew --prefix llvm@22)/bin" >> $GITHUB_PATH
-
-      - name: Print LLVM tool versions
-        run: |
-          clang --version
-          clang-format --version
-          clang-tidy --version
-
-      - name: Clone Flutter
-        run: |
-          git clone --branch stable https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
-          echo "$RUNNER_TEMP/flutter/bin" >> $GITHUB_PATH
-
-      - name: Install Flutter
-        run: flutter doctor
-
-      - name: Get root dependencies
-        run: flutter pub get
-
-      - name: Get codegen dependencies
-        working-directory: codegen
-        run: flutter pub get
-
-      - name: Get analyzer plugin dependencies
-        working-directory: tools/anthem_analyzer_plugin
-        run: dart pub get
-
-      - name: Run code generation
-        run: dart run anthem:cli codegen generate --explicit-format-for-ci
-
-      - name: Format code
-        run: dart format . --set-exit-if-changed -o none
-
-      - name: Lint code
-        run: |
-          mkdir -p assets/engine
-          dart analyze --fatal-infos
-
-      - name: Check engine C++ formatting
-        run: dart run anthem:cli engine format --check
-
-      - name: Build engine
-        run: dart run anthem:cli engine build --release
-
-      - name: Lint engine C++ with clang-tidy
-        run: dart run anthem:cli engine lint
-
-      - name: Run engine unit tests
-        run: dart run anthem:cli engine unit-test
-
-      - name: Run Flutter tests
-        run: dart run anthem:cli flutter_test
-
-      - name: Build Flutter
-        run: flutter build macos --verbose --release
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: anthem-macos-${{ matrix.arch }}
-          # https://github.com/actions/upload-artifact#upload-using-multiple-paths-and-exclusions
-          # If a wildcard pattern is used, the path hierarchy will start with the first wildcard pattern
-          path: build/macos/Build/Products/Release/*.app
-
   build-wasm:
     runs-on: ubuntu-latest
 
@@ -283,52 +206,19 @@ jobs:
       - name: Set up Emscripten
         uses: emscripten-core/setup-emsdk@v16
 
+      - name: Install other prerequisites
+        uses: ./.github/actions/install-prereqs
+
       - name: Check out code
         uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - name: Install dependencies
+      - name: Get Dart dependencies
         run: |
-          sudo apt update
-          sudo apt install -y ca-certificates gnupg lsb-release software-properties-common wget
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
-          source /etc/os-release
-          llvm_codename="${UBUNTU_CODENAME:-$VERSION_CODENAME}"
-          sudo add-apt-repository -y "deb https://apt.llvm.org/${llvm_codename}/ llvm-toolchain-${llvm_codename}-22 main"
-          sudo apt update
-          sudo apt install -y ninja-build llvm-22 clang-22 clang-format-22 clang-tidy-22 libx11-dev libxrandr-dev \
-                             libxinerama-dev libxcursor-dev libfreetype-dev \
-                             mesa-common-dev libasound2-dev freeglut3-dev \
-                             libxcomposite-dev libgtk-3-dev libasound2-dev \
-                             libwebkit2gtk-4.1-dev libcurl4-openssl-dev
-          echo "ANTHEM_LLVM_BIN=/usr/lib/llvm-22/bin" >> "$GITHUB_ENV"
-          echo "/usr/lib/llvm-22/bin" >> "$GITHUB_PATH"
-
-      - name: Print LLVM tool versions
-        run: |
-          clang --version
-          clang-format --version
-          clang-tidy --version
-
-      - name: Clone Flutter
-        run: |
-          git clone --branch stable https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
-          echo "$RUNNER_TEMP/flutter/bin" >> $GITHUB_PATH
-
-      - name: Install Flutter
-        run: flutter doctor
-
-      - name: Get root dependencies
-        run: flutter pub get
-
-      - name: Get codegen dependencies
-        working-directory: codegen
-        run: flutter pub get
-
-      - name: Get analyzer plugin dependencies
-        working-directory: tools/anthem_analyzer_plugin
-        run: dart pub get
+          flutter pub get
+          (cd codegen && flutter pub get)
+          (cd tools/anthem_analyzer_plugin && dart pub get)
 
       - name: Run code generation
         run: dart run anthem:cli codegen generate --explicit-format-for-ci

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,22 +19,8 @@ jobs:
             arch: arm64
 
     steps:
-      - name: Install prerequisites
-        uses: ./.github/actions/install-prereqs
-
-      - name: Check out code
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Get Dart dependencies
-        run: |
-          flutter pub get
-          (cd codegen && flutter pub get)
-          (cd tools/anthem_analyzer_plugin && dart pub get)
-
-      - name: Run code generation
-        run: dart run anthem:cli codegen generate --explicit-format-for-ci
+      - name: Initialize project
+        uses: ./.github/actions/shared-init
 
       - name: Format code
         run: dart format . --set-exit-if-changed -o none
@@ -80,22 +66,8 @@ jobs:
             arch: x64
 
     steps:
-      - name: Install prerequisites
-        uses: ./.github/actions/install-prereqs
-
-      - name: Check out code
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Get Dart dependencies
-        run: |
-          flutter pub get
-          (cd codegen && flutter pub get)
-          (cd tools/anthem_analyzer_plugin && dart pub get)
-
-      - name: Run code generation
-        run: dart run anthem:cli codegen generate --explicit-format-for-ci
+      - name: Initialize project
+        uses: ./.github/actions/shared-init
 
       - name: Format code
         run: dart format . --set-exit-if-changed -o none
@@ -143,24 +115,8 @@ jobs:
             arch: arm64
 
     steps:
-      - name: Install prerequisites
-        uses: ./.github/actions/install-prereqs
-
-      - name: Check out code
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Get root dependencies
-        run: |
-          flutter pub get
-          cd codegen
-          flutter pub get
-          cd ..\tools\anthem_analyzer_plugin
-          dart pub get
-
-      - name: Run code generation
-        run: dart run anthem:cli codegen generate --explicit-format-for-ci
+      - name: Initialize project
+        uses: ./.github/actions/shared-init
 
       - name: Format code
         run: dart format . --set-exit-if-changed -o none
@@ -203,28 +159,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Emscripten
-        uses: emscripten-core/setup-emsdk@v16
-
-      - name: Install other prerequisites
-        uses: ./.github/actions/install-prereqs
-
-      - name: Check out code
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Get Dart dependencies
-        run: |
-          flutter pub get
-          (cd codegen && flutter pub get)
-          (cd tools/anthem_analyzer_plugin && dart pub get)
-
-      - name: Run code generation
-        run: dart run anthem:cli codegen generate --explicit-format-for-ci
+      - name: Initialize project
+        uses: ./.github/actions/shared-init
 
       - name: Format code
         run: dart format . --set-exit-if-changed -o none
+
+      - name: Set up Emscripten
+        uses: emscripten-core/setup-emsdk@v16
 
       - name: Build engine
         run: dart run anthem:cli engine build --release --wasm

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,11 @@ jobs:
             arch: arm64
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
       - name: Initialize project
         uses: ./.github/actions/shared-init
 
@@ -46,6 +51,11 @@ jobs:
             arch: x64
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
       - name: Initialize project
         uses: ./.github/actions/shared-init
 
@@ -75,6 +85,11 @@ jobs:
             arch: arm64
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
       - name: Initialize project
         uses: ./.github/actions/shared-init
 
@@ -99,6 +114,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
       - name: Initialize project
         uses: ./.github/actions/shared-init
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - '**'
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,39 +7,24 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-linux:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: windows-latest
-            arch: x64
-          - os: windows-11-arm
-            arch: arm64
           - os: ubuntu-latest
             arch: x64
           - os: ubuntu-24.04-arm
             arch: arm64
-          - os: macos-latest
-            arch: arm64
-          - os: macos-15-intel
-            arch: x64
-          - os: ubuntu-latest
-            arch: wasm
 
     steps:
-      - name: Set up Emscripten
-        if: matrix.arch == 'wasm'
-        uses: emscripten-core/setup-emsdk@v16
-
       - name: Check out code
         uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - name: Install apt dependencies
-        if: contains(matrix.os, 'ubuntu')
+      - name: Install dependencies
         run: |
           sudo apt update
           sudo apt install -y ca-certificates gnupg lsb-release software-properties-common wget
@@ -56,44 +41,20 @@ jobs:
           echo "ANTHEM_LLVM_BIN=/usr/lib/llvm-22/bin" >> "$GITHUB_ENV"
           echo "/usr/lib/llvm-22/bin" >> "$GITHUB_PATH"
 
-      - name: Install Windows dependencies
-        if: contains(matrix.os, 'windows')
-        run: |
-          choco install llvm --version=22.1.0 -y
-          choco install ninja -y
-          Add-Content $env:GITHUB_ENV 'ANTHEM_LLVM_BIN=C:\Program Files\LLVM\bin'
-          Add-Content $env:GITHUB_PATH 'C:\Program Files\LLVM\bin'
-          Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\bin'
-
-      - name: Install macOS dependencies
-        if: contains(matrix.os, 'macos')
-        run: |
-          brew install llvm@22 ninja
-          echo "ANTHEM_LLVM_BIN=$(brew --prefix llvm@22)/bin" >> $GITHUB_ENV
-          echo "$(brew --prefix llvm@22)/bin" >> $GITHUB_PATH
-
       - name: Print LLVM tool versions
-        if: matrix.arch != 'wasm'
         run: |
           clang --version
           clang-format --version
           clang-tidy --version
 
-      - name: Clone Flutter (Windows)
-        if: contains(matrix.os, 'windows')
-        run: |
-          git clone --branch stable https://github.com/flutter/flutter.git $env:RUNNER_TEMP\flutter
-          Add-Content $env:GITHUB_PATH "$env:RUNNER_TEMP\flutter\bin"
-
-      - name: Clone Flutter (Linux, macOS)
-        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
+      - name: Clone Flutter
         run: |
           git clone --branch stable https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
           echo "$RUNNER_TEMP/flutter/bin" >> $GITHUB_PATH
 
       - name: Install Flutter
         run: flutter doctor
-      
+
       - name: Get root dependencies
         run: flutter pub get
 
@@ -111,60 +72,115 @@ jobs:
       - name: Format code
         run: dart format . --set-exit-if-changed -o none
 
-      - name: Lint code (Windows)
-        if: contains(matrix.os, 'windows')
-        run: |
-          mkdir assets\engine
-          dart analyze --fatal-infos
-      
-      - name: Lint code (Linux, macOS)
-        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
+      - name: Lint code
         run: |
           mkdir -p assets/engine
           dart analyze --fatal-infos
 
       - name: Check engine C++ formatting
-        if: matrix.arch != 'wasm'
         run: dart run anthem:cli engine format --check
 
-      - name: Build engine (desktop)
-        if: matrix.arch != 'wasm'
+      - name: Build engine
         run: dart run anthem:cli engine build --release
 
-      - name: Build engine (WASM)
-        if: matrix.arch == 'wasm'
-        run: dart run anthem:cli engine build --release --wasm
-
       - name: Lint engine C++ with clang-tidy
-        if: matrix.arch != 'wasm'
         run: dart run anthem:cli engine lint
 
       - name: Run engine unit tests
-        if: matrix.arch != 'wasm'
         run: dart run anthem:cli engine unit-test
 
       - name: Run Flutter tests
-        if: matrix.arch != 'wasm'
         run: dart run anthem:cli flutter_test
 
-      - name: Build Flutter (Windows)
-        if: contains(matrix.os, 'windows')
-        run: flutter build windows --verbose --release
-        
-      - name: Build Flutter (Linux)
-        if: contains(matrix.os, 'ubuntu') && matrix.arch != 'wasm'
+      - name: Build Flutter
         run: flutter build linux --verbose --release
-      
-      - name: Build Flutter (macOS)
-        if: contains(matrix.os, 'macos')
-        run: flutter build macos --verbose --release
 
-      - name: Build Flutter (WASM)
-        if: matrix.arch == 'wasm'
-        run: flutter build web --verbose --release --wasm
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: anthem-linux-${{ matrix.arch }}
+          path: build/linux/${{ matrix.arch }}/release/bundle
 
-      - name: Upload artifact (Windows)
-        if: contains(matrix.os, 'windows')
+  build-windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            arch: x64
+          - os: windows-11-arm
+            arch: arm64
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          choco install llvm --version=22.1.0 -y
+          choco install ninja -y
+          Add-Content $env:GITHUB_ENV 'ANTHEM_LLVM_BIN=C:\Program Files\LLVM\bin'
+          Add-Content $env:GITHUB_PATH 'C:\Program Files\LLVM\bin'
+          Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\bin'
+
+      - name: Print LLVM tool versions
+        run: |
+          clang --version
+          clang-format --version
+          clang-tidy --version
+
+      - name: Clone Flutter
+        run: |
+          git clone --branch stable https://github.com/flutter/flutter.git $env:RUNNER_TEMP\flutter
+          Add-Content $env:GITHUB_PATH "$env:RUNNER_TEMP\flutter\bin"
+
+      - name: Install Flutter
+        run: flutter doctor
+
+      - name: Get root dependencies
+        run: flutter pub get
+
+      - name: Get codegen dependencies
+        working-directory: codegen
+        run: flutter pub get
+
+      - name: Get analyzer plugin dependencies
+        working-directory: tools/anthem_analyzer_plugin
+        run: dart pub get
+
+      - name: Run code generation
+        run: dart run anthem:cli codegen generate --explicit-format-for-ci
+
+      - name: Format code
+        run: dart format . --set-exit-if-changed -o none
+
+      - name: Lint code
+        run: |
+          mkdir assets\engine
+          dart analyze --fatal-infos
+
+      - name: Check engine C++ formatting
+        run: dart run anthem:cli engine format --check
+
+      - name: Build engine
+        run: dart run anthem:cli engine build --release
+
+      - name: Lint engine C++ with clang-tidy
+        run: dart run anthem:cli engine lint
+
+      - name: Run engine unit tests
+        run: dart run anthem:cli engine unit-test
+
+      - name: Run Flutter tests
+        run: dart run anthem:cli flutter_test
+
+      - name: Build Flutter
+        run: flutter build windows --verbose --release
+
+      - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: anthem-windows-${{ matrix.arch }}
@@ -175,15 +191,84 @@ jobs:
           # below.
           path: build/windows/x64/runner/Release
 
-      - name: Upload artifact (Linux)
-        if: contains(matrix.os, 'ubuntu') && matrix.arch != 'wasm'
-        uses: actions/upload-artifact@v7
-        with:
-          name: anthem-linux-${{ matrix.arch }}
-          path: build/linux/${{ matrix.arch }}/release/bundle
+  build-macos:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            arch: arm64
+          - os: macos-15-intel
+            arch: x64
 
-      - name: Upload artifact (macOS)
-        if: contains(matrix.os, 'macos')
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          brew install llvm@22 ninja
+          echo "ANTHEM_LLVM_BIN=$(brew --prefix llvm@22)/bin" >> $GITHUB_ENV
+          echo "$(brew --prefix llvm@22)/bin" >> $GITHUB_PATH
+
+      - name: Print LLVM tool versions
+        run: |
+          clang --version
+          clang-format --version
+          clang-tidy --version
+
+      - name: Clone Flutter
+        run: |
+          git clone --branch stable https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
+          echo "$RUNNER_TEMP/flutter/bin" >> $GITHUB_PATH
+
+      - name: Install Flutter
+        run: flutter doctor
+
+      - name: Get root dependencies
+        run: flutter pub get
+
+      - name: Get codegen dependencies
+        working-directory: codegen
+        run: flutter pub get
+
+      - name: Get analyzer plugin dependencies
+        working-directory: tools/anthem_analyzer_plugin
+        run: dart pub get
+
+      - name: Run code generation
+        run: dart run anthem:cli codegen generate --explicit-format-for-ci
+
+      - name: Format code
+        run: dart format . --set-exit-if-changed -o none
+
+      - name: Lint code
+        run: |
+          mkdir -p assets/engine
+          dart analyze --fatal-infos
+
+      - name: Check engine C++ formatting
+        run: dart run anthem:cli engine format --check
+
+      - name: Build engine
+        run: dart run anthem:cli engine build --release
+
+      - name: Lint engine C++ with clang-tidy
+        run: dart run anthem:cli engine lint
+
+      - name: Run engine unit tests
+        run: dart run anthem:cli engine unit-test
+
+      - name: Run Flutter tests
+        run: dart run anthem:cli flutter_test
+
+      - name: Build Flutter
+        run: flutter build macos --verbose --release
+
+      - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: anthem-macos-${{ matrix.arch }}
@@ -191,16 +276,80 @@ jobs:
           # If a wildcard pattern is used, the path hierarchy will start with the first wildcard pattern
           path: build/macos/Build/Products/Release/*.app
 
+  build-wasm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Emscripten
+        uses: emscripten-core/setup-emsdk@v16
+
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y ca-certificates gnupg lsb-release software-properties-common wget
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+          source /etc/os-release
+          llvm_codename="${UBUNTU_CODENAME:-$VERSION_CODENAME}"
+          sudo add-apt-repository -y "deb https://apt.llvm.org/${llvm_codename}/ llvm-toolchain-${llvm_codename}-22 main"
+          sudo apt update
+          sudo apt install -y ninja-build llvm-22 clang-22 clang-format-22 clang-tidy-22 libx11-dev libxrandr-dev \
+                             libxinerama-dev libxcursor-dev libfreetype-dev \
+                             mesa-common-dev libasound2-dev freeglut3-dev \
+                             libxcomposite-dev libgtk-3-dev libasound2-dev \
+                             libwebkit2gtk-4.1-dev libcurl4-openssl-dev
+          echo "ANTHEM_LLVM_BIN=/usr/lib/llvm-22/bin" >> "$GITHUB_ENV"
+          echo "/usr/lib/llvm-22/bin" >> "$GITHUB_PATH"
+
+      - name: Print LLVM tool versions
+        run: |
+          clang --version
+          clang-format --version
+          clang-tidy --version
+
+      - name: Clone Flutter
+        run: |
+          git clone --branch stable https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
+          echo "$RUNNER_TEMP/flutter/bin" >> $GITHUB_PATH
+
+      - name: Install Flutter
+        run: flutter doctor
+
+      - name: Get root dependencies
+        run: flutter pub get
+
+      - name: Get codegen dependencies
+        working-directory: codegen
+        run: flutter pub get
+
+      - name: Get analyzer plugin dependencies
+        working-directory: tools/anthem_analyzer_plugin
+        run: dart pub get
+
+      - name: Run code generation
+        run: dart run anthem:cli codegen generate --explicit-format-for-ci
+
+      - name: Format code
+        run: dart format . --set-exit-if-changed -o none
+
+      - name: Build engine
+        run: dart run anthem:cli engine build --release --wasm
+
+      - name: Build Flutter
+        run: flutter build web --verbose --release --wasm
+
       - name: Install Node.js
-        if: matrix.arch == 'wasm'
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          
+
       - name: Deploy web build to CloudFlare Pages
-        if: matrix.arch == 'wasm'
         run: |
-          export CLOUDFLARE_API_TOKEN=${{ secrets.CLOUDFLARE_API_TOKEN }}
-        
           npm i -g wrangler@latest
           wrangler pages deploy build/web --project-name=anthem-audio --branch=${{ github.ref_name }} --commit-dirty=true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,28 +22,8 @@ jobs:
       - name: Initialize project
         uses: ./.github/actions/shared-init
 
-      - name: Format code
-        run: dart format . --set-exit-if-changed -o none
-
-      - name: Lint code
-        run: |
-          mkdir -p assets/engine
-          dart analyze --fatal-infos
-
-      - name: Check engine C++ formatting
-        run: dart run anthem:cli engine format --check
-
       - name: Build engine
         run: dart run anthem:cli engine build --release
-
-      - name: Lint engine C++ with clang-tidy
-        run: dart run anthem:cli engine lint
-
-      - name: Run engine unit tests
-        run: dart run anthem:cli engine unit-test
-
-      - name: Run Flutter tests
-        run: dart run anthem:cli flutter_test
 
       - name: Build Flutter
         run: flutter build linux --verbose --release
@@ -69,28 +49,8 @@ jobs:
       - name: Initialize project
         uses: ./.github/actions/shared-init
 
-      - name: Format code
-        run: dart format . --set-exit-if-changed -o none
-
-      - name: Lint code
-        run: |
-          mkdir -p assets/engine
-          dart analyze --fatal-infos
-
-      - name: Check engine C++ formatting
-        run: dart run anthem:cli engine format --check
-
       - name: Build engine
         run: dart run anthem:cli engine build --release
-
-      - name: Lint engine C++ with clang-tidy
-        run: dart run anthem:cli engine lint
-
-      - name: Run engine unit tests
-        run: dart run anthem:cli engine unit-test
-
-      - name: Run Flutter tests
-        run: dart run anthem:cli flutter_test
 
       - name: Build Flutter
         run: flutter build macos --verbose --release
@@ -118,28 +78,8 @@ jobs:
       - name: Initialize project
         uses: ./.github/actions/shared-init
 
-      - name: Format code
-        run: dart format . --set-exit-if-changed -o none
-
-      - name: Lint code
-        run: |
-          mkdir assets\engine
-          dart analyze --fatal-infos
-
-      - name: Check engine C++ formatting
-        run: dart run anthem:cli engine format --check
-
       - name: Build engine
         run: dart run anthem:cli engine build --release
-
-      - name: Lint engine C++ with clang-tidy
-        run: dart run anthem:cli engine lint
-
-      - name: Run engine unit tests
-        run: dart run anthem:cli engine unit-test
-
-      - name: Run Flutter tests
-        run: dart run anthem:cli flutter_test
 
       - name: Build Flutter
         run: flutter build windows --verbose --release
@@ -161,9 +101,6 @@ jobs:
     steps:
       - name: Initialize project
         uses: ./.github/actions/shared-init
-
-      - name: Format code
-        run: dart format . --set-exit-if-changed -o none
 
       - name: Set up Emscripten
         uses: emscripten-core/setup-emsdk@v16

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
       - name: Initialize project
         uses: ./.github/actions/shared-init
 
@@ -38,6 +43,11 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
       - name: Initialize project
         uses: ./.github/actions/shared-init
 
@@ -65,6 +75,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
       - name: Initialize project
         uses: ./.github/actions/shared-init
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,89 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Initialize project
+        uses: ./.github/actions/shared-init
+
+      - name: Format code
+        run: dart format . --set-exit-if-changed -o none
+
+      - name: Lint code
+        run: |
+          mkdir -p assets/engine
+          dart analyze --fatal-infos
+
+      - name: Check engine C++ formatting
+        run: dart run anthem:cli engine format --check
+
+      - name: Lint engine C++ with clang-tidy
+        run: dart run anthem:cli engine lint
+
+      - name: Run engine unit tests
+        run: dart run anthem:cli engine unit-test
+
+      - name: Run Flutter tests
+        run: dart run anthem:cli flutter_test
+
+  lint-macos:
+    runs-on: macos-latest
+
+    steps:
+      - name: Initialize project
+        uses: ./.github/actions/shared-init
+
+      - name: Format code
+        run: dart format . --set-exit-if-changed -o none
+
+      - name: Lint code
+        run: |
+          mkdir -p assets/engine
+          dart analyze --fatal-infos
+
+      - name: Check engine C++ formatting
+        run: dart run anthem:cli engine format --check
+
+      - name: Lint engine C++ with clang-tidy
+        run: dart run anthem:cli engine lint
+
+      - name: Run engine unit tests
+        run: dart run anthem:cli engine unit-test
+
+      - name: Run Flutter tests
+        run: dart run anthem:cli flutter_test
+
+  lint-windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Initialize project
+        uses: ./.github/actions/shared-init
+
+      - name: Format code
+        run: dart format . --set-exit-if-changed -o none
+
+      - name: Lint code
+        run: |
+          mkdir assets\engine
+          dart analyze --fatal-infos
+
+      - name: Check engine C++ formatting
+        run: dart run anthem:cli engine format --check
+
+      - name: Lint engine C++ with clang-tidy
+        run: dart run anthem:cli engine lint
+
+      - name: Run engine unit tests
+        run: dart run anthem:cli engine unit-test
+
+      - name: Run Flutter tests
+        run: dart run anthem:cli flutter_test

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,5 +44,8 @@ jobs:
       - name: Run engine unit tests
         run: dart run anthem:cli engine unit-test
 
+      - name: Build engine
+        run: dart run anthem:cli engine build --release
+
       - name: Run Flutter tests
         run: dart run anthem:cli flutter_test

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,8 +7,15 @@ on:
   pull_request:
 
 jobs:
-  lint-linux:
-    runs-on: ubuntu-latest
+  lint:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+          - os: windows-latest
 
     steps:
       - name: Check out code
@@ -23,72 +30,9 @@ jobs:
         run: dart format . --set-exit-if-changed -o none
 
       - name: Lint code
+        shell: bash
         run: |
           mkdir -p assets/engine
-          dart analyze --fatal-infos
-
-      - name: Check engine C++ formatting
-        run: dart run anthem:cli engine format --check
-
-      - name: Lint engine C++ with clang-tidy
-        run: dart run anthem:cli engine lint
-
-      - name: Run engine unit tests
-        run: dart run anthem:cli engine unit-test
-
-      - name: Run Flutter tests
-        run: dart run anthem:cli flutter_test
-
-  lint-macos:
-    runs-on: macos-latest
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Initialize project
-        uses: ./.github/actions/shared-init
-
-      - name: Format code
-        run: dart format . --set-exit-if-changed -o none
-
-      - name: Lint code
-        run: |
-          mkdir -p assets/engine
-          dart analyze --fatal-infos
-
-      - name: Check engine C++ formatting
-        run: dart run anthem:cli engine format --check
-
-      - name: Lint engine C++ with clang-tidy
-        run: dart run anthem:cli engine lint
-
-      - name: Run engine unit tests
-        run: dart run anthem:cli engine unit-test
-
-      - name: Run Flutter tests
-        run: dart run anthem:cli flutter_test
-
-  lint-windows:
-    runs-on: windows-latest
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Initialize project
-        uses: ./.github/actions/shared-init
-
-      - name: Format code
-        run: dart format . --set-exit-if-changed -o none
-
-      - name: Lint code
-        run: |
-          mkdir assets\engine
           dart analyze --fatal-infos
 
       - name: Check engine C++ formatting


### PR DESCRIPTION
Changes:

- Add a composite action that contains all the steps that are required for every workflow (install build tools, install Flutter, checkout, `pub get`, codegen)
- Split build workflow into different jobs for each OS
- Move lint steps into their own workflow